### PR TITLE
Fix: Fix image loading on node style properties

### DIFF
--- a/src/models/graph.ts
+++ b/src/models/graph.ts
@@ -48,10 +48,10 @@ export class Graph<N extends INodeBase, E extends IEdgeBase> implements IGraph<N
   private _onLoadedImages?: () => void;
 
   constructor(data?: Partial<IGraphData<N, E>>, settings?: Partial<IGraphSettings>) {
+    this._onLoadedImages = settings?.onLoadedImages;
     const nodes = data?.nodes ?? [];
     const edges = data?.edges ?? [];
     this.setup({ nodes, edges });
-    this._onLoadedImages = settings?.onLoadedImages;
   }
 
   /**
@@ -328,7 +328,7 @@ export class Graph<N extends INodeBase, E extends IEdgeBase> implements IGraph<N
 
   private _insertNodes(nodes: N[]) {
     for (let i = 0; i < nodes.length; i++) {
-      const node = NodeFactory.create<N, E>({ data: nodes[i] });
+      const node = NodeFactory.create<N, E>({ data: nodes[i] }, { onLoadedImage: () => this._onLoadedImages?.() });
       this._nodeById[node.id] = node;
     }
   }
@@ -357,7 +357,7 @@ export class Graph<N extends INodeBase, E extends IEdgeBase> implements IGraph<N
         continue;
       }
 
-      const node = NodeFactory.create<N, E>({ data: nodes[i] });
+      const node = NodeFactory.create<N, E>({ data: nodes[i] }, { onLoadedImage: () => this._onLoadedImages?.() });
       this._nodeById[node.id] = node;
     }
   }


### PR DESCRIPTION
It fixes the following issue:

```typescript
orb.data.setDefaultStyle({
  getNodeStyle(node) {
    return {
      imageUrl: "https://image.com/image.png",
    };
  },
});

orb.data.setup({ nodes, edges });

orb.view.render();

const node = orb.data.getNodesById(0);
node.style.imageUrl = "https://image.com/new-image.png"
```

Orb knows about default style and it will check each default style when applied to new nodes. This means it will check for values in `imageUrl` and `imageUrlSelected` in order to get those images in the browser cache. The problem is that the line where `node.style.imageUrl` is set, Orb doesn't know about it, so the image is never loaded in the browser cache, not it will be rendered.
So a `Graph` that is connected to the `ImageHandler` service that fetches images is now using the node's callback in order to figure out if there are new image URLs that should be fetched. After each new image that is downloaded, Orb will call `render` on its own to rerender the image that is available in the browser cache.