### PR TITLE
Fix: Fix undefined subject on mouse hover event

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/orb.iml" filepath="$PROJECT_DIR$/.idea/orb.iml" />
-    </modules>
-  </component>
-</project>

--- a/src/models/strategy.ts
+++ b/src/models/strategy.ts
@@ -16,52 +16,6 @@ export interface IEventStrategy<N extends INodeBase, E extends IEdgeBase> {
 
 export const getDefaultEventStrategy = <N extends INodeBase, E extends IEdgeBase>(): IEventStrategy<N, E> => {
   return new DefaultEventStrategy<N, E>();
-  // return {
-  //   onMouseClick: (graph: IGraph<N, E>, point: IPosition): IEventStrategyResponse<N, E> => {
-  //     const node = graph.getNearestNode(point);
-  //     if (node) {
-  //       selectNode(graph, node);
-  //       return {
-  //         isStateChanged: true,
-  //         changedSubject: node,
-  //       };
-  //     }
-  //
-  //     const edge = graph.getNearestEdge(point);
-  //     if (edge) {
-  //       selectEdge(graph, edge);
-  //       return {
-  //         isStateChanged: true,
-  //         changedSubject: edge,
-  //       };
-  //     }
-  //
-  //     const { changedCount } = unselectAll(graph);
-  //     return {
-  //       isStateChanged: changedCount > 0,
-  //     };
-  //   },
-  //   onMouseMove: (graph: IGraph<N, E>, point: IPosition): IEventStrategyResponse<N, E> => {
-  //     // From map view
-  //     const node = graph.getNearestNode(point);
-  //     if (node && !node.isSelected()) {
-  //       hoverNode(graph, node);
-  //       return {
-  //         isStateChanged: true,
-  //         changedSubject: node,
-  //       };
-  //     }
-  //
-  //     if (!node) {
-  //       const { changedCount } = unhoverAll(graph);
-  //       return {
-  //         isStateChanged: changedCount > 0,
-  //       };
-  //     }
-  //
-  //     return { isStateChanged: false };
-  //   },
-  // };
 };
 
 class DefaultEventStrategy<N extends INodeBase, E extends IEdgeBase> implements IEventStrategy<N, E> {
@@ -97,6 +51,7 @@ class DefaultEventStrategy<N extends INodeBase, E extends IEdgeBase> implements 
     if (node && !node.isSelected()) {
       if (node === this.lastHoveredNode) {
         return {
+          changedSubject: node,
           isStateChanged: false,
         };
       }

--- a/src/views/default-view.ts
+++ b/src/views/default-view.ts
@@ -316,7 +316,7 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
       const response = this._strategy.onMouseMove(this._graph, simulationPoint);
       const subject = response.changedSubject;
 
-      if (subject) {
+      if (subject && response.isStateChanged) {
         if (isNode(subject)) {
           this._events.emit(OrbEventType.NODE_HOVER, {
             node: subject,
@@ -342,7 +342,7 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
         globalPoint: mousePoint,
       });
 
-      if (response.isStateChanged || response.changedSubject) {
+      if (response.isStateChanged) {
         // TODO: Add throttle render
         this._renderer.render(this._graph);
       }

--- a/src/views/map-view.ts
+++ b/src/views/map-view.ts
@@ -221,7 +221,7 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
         const response = this._strategy.onMouseMove(this._graph, point);
         const subject = response.changedSubject;
 
-        if (subject) {
+        if (subject && response.isStateChanged) {
           if (isNode(subject)) {
             this._events.emit(OrbEventType.NODE_HOVER, {
               node: subject,
@@ -247,7 +247,7 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
           globalPoint: containerPoint,
         });
 
-        if (response.isStateChanged || response.changedSubject) {
+        if (response.isStateChanged) {
           this._renderer.render(this._graph);
         }
       }


### PR DESCRIPTION
Issue: When hovering over nodes/edges, the `OrbEventType.MOUSE_MOVE` event will have a defined subject (node or edge) only on the first event, but it should be present in all `MOUSE_MOVE` events while the mouse pointer is on top of the node or edge.

* `OrbEventType.MOUSE_MOVE` will be emitted for each mouse move event. If the mouse pointer is on top of the node or edge, `event.subject` will be a node or an edge object. If the mouse pointer is not on top of node or edge, `event.subject` will be `undefined`.
* `OrbEventType.NODE_HOVER` will be triggered only once for each subject: a node or an edge. It is like a "mouse pointer entered node space".