### PR TITLE
Fix: Add throttle render to renderer via fps settings

### DIFF
--- a/docs/view-default.md
+++ b/docs/view-default.md
@@ -69,6 +69,7 @@ interface IDefaultViewSettings {
   };
   // For canvas rendering and events
   render: {
+    fps: number;
     minZoom: number;
     maxZoom: number;
     fitZoomMargin: number;
@@ -132,6 +133,7 @@ const defaultSettings = {
     },
   },
   render: {
+    fps: 60,
     minZoom: 0.25,
     maxZoom: 8,
     fitZoomMargin: 0.2,

--- a/docs/view-map.md
+++ b/docs/view-map.md
@@ -122,6 +122,7 @@ interface IMapViewSettings {
   getGeoPosition(node: INode): { lat: number; lng: number } | undefined;
   // For canvas rendering and events
   render: {
+    fps: number;
     minZoom: number;
     maxZoom: number;
     fitZoomMargin: number;
@@ -146,6 +147,7 @@ The default settings that `MapView` uses is:
 ```typescript
 const defaultSettings = {
   render: {
+    fps: 60,
     minZoom: 0.25,
     maxZoom: 8,
     fitZoomMargin: 0.2,

--- a/src/renderer/factory.ts
+++ b/src/renderer/factory.ts
@@ -2,25 +2,27 @@ import { CanvasRenderer } from './canvas/canvas-renderer';
 import { IRenderer, IRendererSettings, RendererType } from './shared';
 import { WebGLRenderer } from './webgl/webgl-renderer';
 import { OrbError } from '../exceptions';
+import { INodeBase } from '../models/node';
+import { IEdgeBase } from '../models/edge';
 
 export class RendererFactory {
-  static getRenderer(
+  static getRenderer<N extends INodeBase, E extends IEdgeBase>(
     canvas: HTMLCanvasElement,
     type: RendererType = RendererType.CANVAS,
     settings?: Partial<IRendererSettings>,
-  ): IRenderer {
+  ): IRenderer<N, E> {
     if (type === RendererType.WEBGL) {
       const context = canvas.getContext('webgl2');
       if (!context) {
         throw new OrbError('Failed to create WebGL context.');
       }
-      return new WebGLRenderer(context, settings);
+      return new WebGLRenderer<N, E>(context, settings);
     }
 
     const context = canvas.getContext('2d');
     if (!context) {
       throw new OrbError('Failed to create Canvas context.');
     }
-    return new CanvasRenderer(context, settings);
+    return new CanvasRenderer<N, E>(context, settings);
   }
 }

--- a/src/renderer/shared.ts
+++ b/src/renderer/shared.ts
@@ -37,7 +37,7 @@ export type RendererEvents = {
   [RenderEventType.RENDER_END]: { durationMs: number };
 };
 
-export interface IRenderer extends IEmitter<RendererEvents> {
+export interface IRenderer<N extends INodeBase, E extends IEdgeBase> extends IEmitter<RendererEvents> {
   // Width and height of the canvas. Used for clearing.
   width: number;
   height: number;
@@ -52,11 +52,11 @@ export interface IRenderer extends IEmitter<RendererEvents> {
 
   setSettings(settings: Partial<IRendererSettings>): void;
 
-  render<N extends INodeBase, E extends IEdgeBase>(graph: IGraph<N, E>): void;
+  render(graph: IGraph<N, E>): void;
 
   reset(): void;
 
-  getFitZoomTransform<N extends INodeBase, E extends IEdgeBase>(graph: IGraph<N, E>): ZoomTransform;
+  getFitZoomTransform(graph: IGraph<N, E>): ZoomTransform;
 
   getSimulationPosition(canvasPoint: IPosition): IPosition;
 

--- a/src/renderer/shared.ts
+++ b/src/renderer/shared.ts
@@ -16,6 +16,7 @@ export enum RenderEventType {
 }
 
 export interface IRendererSettings {
+  fps: number;
   minZoom: number;
   maxZoom: number;
   fitZoomMargin: number;
@@ -40,13 +41,16 @@ export interface IRenderer extends IEmitter<RendererEvents> {
   // Width and height of the canvas. Used for clearing.
   width: number;
   height: number;
-  settings: IRendererSettings;
 
   // Includes translation (pan) in the x and y direction
   // as well as scaling (level of zoom).
   transform: ZoomTransform;
 
   get isInitiallyRendered(): boolean;
+
+  getSettings(): IRendererSettings;
+
+  setSettings(settings: Partial<IRendererSettings>): void;
 
   render<N extends INodeBase, E extends IEdgeBase>(graph: IGraph<N, E>): void;
 
@@ -67,6 +71,7 @@ export interface IRenderer extends IEmitter<RendererEvents> {
 }
 
 export const DEFAULT_RENDERER_SETTINGS: IRendererSettings = {
+  fps: 60,
   minZoom: 0.25,
   maxZoom: 8,
   fitZoomMargin: 0.2,

--- a/src/renderer/webgl/webgl-renderer.ts
+++ b/src/renderer/webgl/webgl-renderer.ts
@@ -4,18 +4,17 @@ import { IEdgeBase } from '../../models/edge';
 import { IGraph } from '../../models/graph';
 import { IPosition, IRectangle } from '../../common';
 import { Emitter } from '../../utils/emitter.utils';
-import { RendererEvents } from '../shared';
 import {
   DEFAULT_RENDERER_HEIGHT,
   DEFAULT_RENDERER_SETTINGS,
   DEFAULT_RENDERER_WIDTH,
   IRenderer,
+  RendererEvents as RE,
   IRendererSettings,
 } from '../shared';
 import { copyObject } from '../../utils/object.utils';
 
-// STUB
-export class WebGLRenderer extends Emitter<RendererEvents> implements IRenderer {
+export class WebGLRenderer<N extends INodeBase, E extends IEdgeBase> extends Emitter<RE> implements IRenderer<N, E> {
   // Contains the HTML5 Canvas element which is used for drawing nodes and edges.
   private readonly _context: WebGL2RenderingContext;
 
@@ -53,7 +52,7 @@ export class WebGLRenderer extends Emitter<RendererEvents> implements IRenderer 
     };
   }
 
-  render<N extends INodeBase, E extends IEdgeBase>(graph: IGraph<N, E>): void {
+  render(graph: IGraph<N, E>): void {
     console.log('graph:', graph);
     throw new Error('Method not implemented.');
   }
@@ -62,7 +61,7 @@ export class WebGLRenderer extends Emitter<RendererEvents> implements IRenderer 
     throw new Error('Method not implemented.');
   }
 
-  getFitZoomTransform<N extends INodeBase, E extends IEdgeBase>(graph: IGraph<N, E>): ZoomTransform {
+  getFitZoomTransform(graph: IGraph<N, E>): ZoomTransform {
     console.log('graph:', graph);
     throw new Error('Method not implemented.');
   }

--- a/src/renderer/webgl/webgl-renderer.ts
+++ b/src/renderer/webgl/webgl-renderer.ts
@@ -12,6 +12,7 @@ import {
   IRenderer,
   IRendererSettings,
 } from '../shared';
+import { copyObject } from '../../utils/object.utils';
 
 // STUB
 export class WebGLRenderer extends Emitter<RendererEvents> implements IRenderer {
@@ -20,7 +21,7 @@ export class WebGLRenderer extends Emitter<RendererEvents> implements IRenderer 
 
   width: number;
   height: number;
-  settings: IRendererSettings;
+  private _settings: IRendererSettings;
   transform: ZoomTransform;
 
   constructor(context: WebGL2RenderingContext, settings?: Partial<IRendererSettings>) {
@@ -31,7 +32,7 @@ export class WebGLRenderer extends Emitter<RendererEvents> implements IRenderer 
     this.width = DEFAULT_RENDERER_WIDTH;
     this.height = DEFAULT_RENDERER_HEIGHT;
     this.transform = zoomIdentity;
-    this.settings = {
+    this._settings = {
       ...DEFAULT_RENDERER_SETTINGS,
       ...settings,
     };
@@ -40,24 +41,41 @@ export class WebGLRenderer extends Emitter<RendererEvents> implements IRenderer 
   get isInitiallyRendered(): boolean {
     throw new Error('Method not implemented.');
   }
+
+  getSettings(): IRendererSettings {
+    return copyObject(this._settings);
+  }
+
+  setSettings(settings: Partial<IRendererSettings>): void {
+    this._settings = {
+      ...this._settings,
+      ...settings,
+    };
+  }
+
   render<N extends INodeBase, E extends IEdgeBase>(graph: IGraph<N, E>): void {
     console.log('graph:', graph);
     throw new Error('Method not implemented.');
   }
+
   reset(): void {
     throw new Error('Method not implemented.');
   }
+
   getFitZoomTransform<N extends INodeBase, E extends IEdgeBase>(graph: IGraph<N, E>): ZoomTransform {
     console.log('graph:', graph);
     throw new Error('Method not implemented.');
   }
+
   getSimulationPosition(canvasPoint: IPosition): IPosition {
     console.log('canvasPoint:', canvasPoint);
     throw new Error('Method not implemented.');
   }
+
   getSimulationViewRectangle(): IRectangle {
     throw new Error('Method not implemented.');
   }
+
   translateOriginToCenter(): void {
     throw new Error('Method not implemented.');
   }

--- a/src/utils/function.utils.ts
+++ b/src/utils/function.utils.ts
@@ -1,0 +1,28 @@
+export const throttle = (fn: Function, waitMs = 300) => {
+  let isInThrottle = false;
+  let lastTimer: ReturnType<typeof setTimeout>;
+  let lastTimestamp: number = Date.now();
+
+  return function () {
+    // eslint-disable-next-line prefer-rest-params
+    const args = arguments;
+    const now = Date.now();
+
+    if (!isInThrottle) {
+      fn(...args);
+      lastTimestamp = now;
+      isInThrottle = true;
+      return;
+    }
+
+    clearTimeout(lastTimer);
+    const timerWaitMs = Math.max(waitMs - (now - lastTimestamp), 0);
+
+    lastTimer = setTimeout(() => {
+      if (now - lastTimestamp >= waitMs) {
+        fn(...args);
+        lastTimestamp = now;
+      }
+    }, timerWaitMs);
+  };
+};

--- a/src/utils/math.utils.ts
+++ b/src/utils/math.utils.ts
@@ -1,0 +1,4 @@
+export const getThrottleMsFromFPS = (fps: number): number => {
+  const validFps = Math.max(fps, 1);
+  return Math.round(1000 / validFps);
+};

--- a/src/views/default-view.ts
+++ b/src/views/default-view.ts
@@ -45,7 +45,7 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
   private _settings: IDefaultViewSettings<N, E>;
   private _canvas: HTMLCanvasElement;
 
-  private readonly _renderer: IRenderer;
+  private readonly _renderer: IRenderer<N, E>;
   private readonly _simulator: ISimulator;
 
   private _isSimulating = false;
@@ -81,7 +81,7 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
     this._canvas = this._initCanvas();
 
     try {
-      this._renderer = RendererFactory.getRenderer(this._canvas, settings?.render?.type, this._settings.render);
+      this._renderer = RendererFactory.getRenderer<N, E>(this._canvas, settings?.render?.type, this._settings.render);
     } catch (error: any) {
       this._container.textContent = error.message;
       throw error;
@@ -138,7 +138,6 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
       this._events.emit(OrbEventType.SIMULATION_END, { durationMs: Date.now() - this._simulationStartedAt });
     });
     this._simulator.on(SimulatorEventType.NODE_DRAG, (data) => {
-      // TODO: Add throttle render (for larger graphs)
       this._graph.setNodePositions(data.nodes);
       this._renderer.render(this._graph);
     });
@@ -245,8 +244,6 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
 
     // A drag event de-selects the node, while a click event selects it.
     if (!isEqualPosition(this._dragStartPosition, mousePoint)) {
-      // this.selectedShape_.next(null);
-      // this.selectedShapePosition_.next(null);
       this._dragStartPosition = undefined;
     }
 
@@ -342,7 +339,6 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
       });
 
       if (response.isStateChanged) {
-        // TODO: Add throttle render
         this._renderer.render(this._graph);
       }
     }

--- a/src/views/default-view.ts
+++ b/src/views/default-view.ts
@@ -93,7 +93,7 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
       this._events.emit(OrbEventType.RENDER_END, data);
     });
     this._renderer.translateOriginToCenter();
-    this._settings.render = this._renderer.settings;
+    this._settings.render = this._renderer.getSettings();
 
     // Resize the canvas based on the dimensions of its parent container <div>.
     const resizeObs = new ResizeObserver(() => this._handleResize());
@@ -101,7 +101,7 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
     this._handleResize();
 
     this._d3Zoom = zoom<HTMLCanvasElement, any>()
-      .scaleExtent([this._renderer.settings.minZoom, this._renderer.settings.maxZoom])
+      .scaleExtent([this._renderer.getSettings().minZoom, this._renderer.getSettings().maxZoom])
       .on('zoom', this.zoomed);
 
     select<HTMLCanvasElement, any>(this._canvas)
@@ -171,11 +171,8 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
     }
 
     if (settings.render) {
-      this._renderer.settings = {
-        ...this._renderer.settings,
-        ...settings.render,
-      };
-      this._settings.render = this._renderer.settings;
+      this._renderer.setSettings(settings.render);
+      this._settings.render = this._renderer.getSettings();
     }
   }
 

--- a/src/views/map-view.ts
+++ b/src/views/map-view.ts
@@ -103,9 +103,8 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
     this._renderer.on(RenderEventType.RENDER_END, (data) => {
       this._events.emit(OrbEventType.RENDER_END, data);
     });
-    this._settings.render = {
-      ...this._renderer.settings,
-    };
+    this._settings.render = this._renderer.getSettings();
+
     // Resize the canvas based on the dimensions of it's parent container <div>.
     const resizeObs = new ResizeObserver(() => this._handleResize());
     resizeObs.observe(this._container);
@@ -147,13 +146,8 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
     }
 
     if (settings.render) {
-      this._renderer.settings = {
-        ...this._renderer.settings,
-        ...settings.render,
-      };
-      this._settings.render = {
-        ...this._renderer.settings,
-      };
+      this._renderer.setSettings(settings.render);
+      this._settings.render = this._renderer.getSettings();
     }
   }
 

--- a/src/views/map-view.ts
+++ b/src/views/map-view.ts
@@ -68,7 +68,7 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
   private _canvas: HTMLCanvasElement;
   private _map: HTMLDivElement;
 
-  private readonly _renderer: IRenderer;
+  private readonly _renderer: IRenderer<N, E>;
   private readonly _leaflet: L.Map;
 
   constructor(context: IOrbViewContext<N, E>, settings: IMapViewSettingsInit<N, E>) {
@@ -95,7 +95,7 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
     this._map = this._initMap();
 
     try {
-      this._renderer = RendererFactory.getRenderer(this._canvas, settings?.render?.type, this._settings.render);
+      this._renderer = RendererFactory.getRenderer<N, E>(this._canvas, settings?.render?.type, this._settings.render);
     } catch (error: any) {
       this._container.textContent = error.message;
       throw error;
@@ -213,7 +213,7 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
     leaflet.on('mousemove', (event: ILeafletEvent<MouseEvent>) => {
       const point: IPosition = { x: event.layerPoint.x, y: event.layerPoint.y };
       const containerPoint: IPosition = { x: event.containerPoint.x, y: event.containerPoint.y };
-      // TODO: Add throttle
+
       if (this._strategy.onMouseMove) {
         const response = this._strategy.onMouseMove(this._graph, point);
         const subject = response.changedSubject;

--- a/test/utils/html.utils.spec.ts
+++ b/test/utils/html.utils.spec.ts
@@ -1,4 +1,4 @@
-import { isCollapsedDimension } from './html.utils';
+import { isCollapsedDimension } from '../../src/utils/html.utils';
 
 describe('html.utils', () => {
   test('should match collapsed style dimensions regex', () => {


### PR DESCRIPTION
Fixes issue: #15 

A throttle is added for `render` calls to skip renders depending on the defined FPS (frame per second) parameter. This will enable users to call `orb.view.render()` within events without fear to have performance issues.

New settings parameter is available, `render.fps`, with a default value of `60`. It can be changed anytime.