### PR TITLE
Fix: Remove render callback after first usage in simulation end

### DIFF
--- a/src/views/default-view.ts
+++ b/src/views/default-view.ts
@@ -135,6 +135,7 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
       this._renderer.render(this._graph);
       this._isSimulating = false;
       this._onSimulationEnd?.();
+      this._onSimulationEnd = undefined;
       this._events.emit(OrbEventType.SIMULATION_END, { durationMs: Date.now() - this._simulationStartedAt });
     });
     this._simulator.on(SimulatorEventType.NODE_DRAG, (data) => {


### PR DESCRIPTION
It fixes the following issue:

If you use Orb like this:

* Render the graph after which you want to `console.log` a message and recenter the graph
* After 5 seconds, change the view settings by enabling physics

```
orb.view.render(() => {
  console.log('Rendering done');
  orb.view.recenter();
});

setTimeout(() => {
  orb.view.setSettings({
    render: {
      isPhysicsEnabled: true,
    },
  });
}, 5000)
```

The problem:

* When enabling the physics, simulation of the nodes will start
* When the simulation ends, it will call the same callback from the first render (`console.log` and recenter)

The solution:

* After calling the user's callback, remove it so it is not called anymore in simulation end event
