### PR TITLE
Fix: Fix multiple maps issue

### DIFF
--- a/src/views/map-view.ts
+++ b/src/views/map-view.ts
@@ -30,9 +30,11 @@ const osmAttribution =
   '<a href="https://leafletjs.com/" target="_blank" >Leaflet</a> | ' +
   'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors';
 
-const DEFAULT_MAP_TILE: ILeafletMapTile = {
-  instance: new L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'),
-  attribution: osmAttribution,
+const getDefaultMapTile = () => {
+  return {
+    instance: new L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'),
+    attribution: osmAttribution,
+  };
 };
 
 const DEFAULT_ZOOM_LEVEL = 2;
@@ -82,7 +84,7 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
       ...settings,
       map: {
         zoomLevel: settings.map?.zoomLevel ?? DEFAULT_ZOOM_LEVEL,
-        tile: settings.map?.tile ?? DEFAULT_MAP_TILE,
+        tile: settings.map?.tile ?? getDefaultMapTile(),
       },
       render: {
         type: RendererType.CANVAS,


### PR DESCRIPTION
Having multiple map views with default map tiles didn't work since they all reused the same tile. Added a factory function to create multiple instances.

![Screenshot 2022-11-04 at 15-22-56 Orb Graph on the map](https://user-images.githubusercontent.com/3769376/199998696-d71416ef-60d4-4eb2-8495-42f98978ae81.png)

