### PR TITLE
Fix web worker build with parcel

### DIFF
--- a/src/simulator/types/web-worker-simulator/simulator.ts
+++ b/src/simulator/types/web-worker-simulator/simulator.ts
@@ -16,6 +16,7 @@ export class WebWorkerSimulator extends Emitter<SimulatorEvents> implements ISim
         './process.worker',
         import.meta.url,
       ),
+      { type: 'module' }
     );
 
     this.worker.onmessage = ({ data }: MessageEvent<IWorkerOutputPayload>) => {


### PR DESCRIPTION
This fixed the issue #28 for me with Parcel. I believe the `module` is needed to instruct the bundler that it's an esmodule and should be bundled.

https://stackoverflow.com/questions/48045569/whats-the-difference-between-a-classic-and-module-web-worker