### PR TITLE
New: Add support for handling device pixel ratio

### DIFF
--- a/docs/view-default.md
+++ b/docs/view-default.md
@@ -63,6 +63,7 @@ interface IOrbViewSettings {
   };
   // For canvas rendering and events
   render: {
+    devicePixelRatio: number | null;
     fps: number;
     minZoom: number;
     maxZoom: number;
@@ -74,6 +75,7 @@ interface IOrbViewSettings {
     contextAlphaOnEvent: number;
     contextAlphaOnEventIsEnabled: boolean;
     backgroundColor: Color | string | null;
+    areCollapsedContainerDimensionsAllowed: boolean;
   };
   // For select and hover look-and-feel
   strategy: {
@@ -85,7 +87,6 @@ interface IOrbViewSettings {
   isOutOfBoundsDragEnabled: boolean;
   areCoordinatesRounded: boolean;
   isSimulationAnimated: boolean;
-  areCollapsedContainerDimensionsAllowed: boolean;
 }
 ```
 
@@ -133,6 +134,7 @@ const defaultSettings = {
     },
   },
   render: {
+    devicePixelRatio: window.devicePixelRatio,
     fps: 60,
     minZoom: 0.25,
     maxZoom: 8,
@@ -144,6 +146,7 @@ const defaultSettings = {
     contextAlphaOnEvent: 0.3,
     contextAlphaOnEventIsEnabled: true,
     backgroundColor: null,
+    areCollapsedContainerDimensionsAllowed: false,
   },
   strategy: {
     isDefaultSelectEnabled: true,
@@ -153,7 +156,6 @@ const defaultSettings = {
   isOutOfBoundsDragEnabled: false,
   areCoordinatesRounded: true,
   isSimulationAnimated: true,
-  areCollapsedContainerDimensionsAllowed: false;
 }
 ```
 
@@ -189,7 +191,7 @@ const edges: MyEdge[] = [
   { id: 0, start: 0, end: 0, label: "Edge Q" },
   { id: 1, start: 0, end: 1, label: "Edge W" },
   { id: 2, start: 0, end: 2, label: "Edge E" },
-  { id: 3, start: 1, end: 2, label: "Edge T" },
+  { id: 3, start: 1, end: 2, label: "Edge Tf" },
   { id: 4, start: 2, end: 2, label: "Edge Y" },
   { id: 5, start: 0, end: 1, label: "Edge V" },
 ];
@@ -259,6 +261,26 @@ Here you can use your original properties to indicate which ones represent your 
 
 Optional property `render` has several rendering options that you can tweak. Read more about them
 on [Styling guide](./styles.md).
+
+#### Property `render.devicePixelRatio`
+
+`devicePixelRatio` is useful when dealing with the difference between rendering on a standard
+display versus a HiDPI or Retina display, which uses more screen pixels to draw the same
+objects, resulting in a sharper image. ([Reference: MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio)).
+Orb will listen for `devicePixelRatio` changes and handles them by default. You can override the
+value with a settings property `render.devicePixelRatio`. Once a custom value is provided, Orb will
+stop listening for `devicePixelRatio` changes.
+If you want to return automatic `devicePixelRatio` handling, just set `render.devicePixelRatio`
+to `null`.
+
+#### Property `render.areCollapsedContainerDimensionsAllowed`
+
+Enables setting the dimensions of the Orb container element to zero.
+If the container element of Orb has collapsed dimensions (`width: 0;` or `height: 0;`),
+Orb will expand the container by setting the values to `100%`.
+If that doesn't work (the parent of the container also has collapsed dimensions),
+Orb will set an arbitrary fixed dimension to the container.
+Disabled by default (`false`).
 
 ### Property `strategy`
 
@@ -337,15 +359,6 @@ Rounds node coordinates to integer values. Slightly improves performance. Enable
 Shows the process of simulation where the nodes are moved by the physics engine until they
 converge to a stable position. If disabled, the graph will suddenly appear in its final position.
 Enabled by default (`true`).
-
-### Property `areCollapsedContainerDimensionsAllowed`
-
-Enables setting the dimensions of the Orb container element to zero.
-If the container element of Orb has collapsed dimensions (`width: 0;` or `height: 0;`),
-Orb will expand the container by setting the values to `100%`.
-If that doesn't work (the parent of the container also has collapsed dimensions),
-Orb will set an arbitrary fixed dimension to the container.
-Disabled by default (`false`).
 
 ## Settings
 

--- a/docs/view-map.md
+++ b/docs/view-map.md
@@ -116,6 +116,7 @@ interface IOrbMapViewSettings {
   getGeoPosition(node: INode): { lat: number; lng: number } | undefined;
   // For canvas rendering and events
   render: {
+    devicePixelRatio: number | null;
     fps: number;
     minZoom: number;
     maxZoom: number;
@@ -147,6 +148,7 @@ The default settings that `OrbMapView` uses is:
 ```typescript
 const defaultSettings = {
   render: {
+    devicePixelRatio: window.devicePixelRatio,
     fps: 60,
     minZoom: 0.25,
     maxZoom: 8,
@@ -190,6 +192,26 @@ Optional property `map` has two properties that you can set which are:
 
 Optional property `render` has several rendering options that you can tweak. Read more about them
 on [Styling guide](./styles.md).
+
+#### Property `render.devicePixelRatio`
+
+`devicePixelRatio` is useful when dealing with the difference between rendering on a standard
+display versus a HiDPI or Retina display, which uses more screen pixels to draw the same
+objects, resulting in a sharper image. ([Reference: MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio)).
+Orb will listen for `devicePixelRatio` changes and handles them by default. You can override the
+value with a settings property `render.devicePixelRatio`. Once a custom value is provided, Orb will
+stop listening for `devicePixelRatio` changes.
+If you want to return automatic `devicePixelRatio` handling, just set `render.devicePixelRatio`
+to `null`.
+
+#### Property `render.areCollapsedContainerDimensionsAllowed`
+
+Enables setting the dimensions of the Orb container element to zero.
+If the container element of Orb has collapsed dimensions (`width: 0;` or `height: 0;`),
+Orb will expand the container by setting the values to `100%`.
+If that doesn't work (the parent of the container also has collapsed dimensions),
+Orb will set an arbitrary fixed dimension to the container.
+Disabled by default (`false`).
 
 ### Property `strategy`
 
@@ -242,15 +264,6 @@ orb.events.on(OrbEventType.MOUSE_CLICK, (event) => {
   }
 });
 ```
-
-### Property `areCollapsedContainerDimensionsAllowed`
-
-Enables setting the dimensions of the Orb container element to zero.
-If the container element of Orb has collapsed dimensions (`width: 0;` or `height: 0;`),
-Orb will expand the container by setting the values to `100%`.
-If that doesn't work (the parent of the container also has collapsed dimensions),
-Orb will set an arbitrary fixed dimension to the container.
-Disabled by default (`false`).
 
 ## Settings
 

--- a/src/renderer/canvas/canvas-renderer.ts
+++ b/src/renderer/canvas/canvas-renderer.ts
@@ -134,7 +134,7 @@ export class CanvasRenderer<N extends INodeBase, E extends IEdgeBase> extends Em
     }
 
     // Change DPR from automatic to manual handling or change DPR value manually
-    if (!isNumber(previousDprValue) && isNumber(newDprValue) && newDprValue !== previousDprValue) {
+    if (!isNumber(previousDprValue) && isNumber(newDprValue)) {
       this._dprObserveUnsubscribe?.();
       this._resize();
     }

--- a/src/renderer/canvas/canvas-renderer.ts
+++ b/src/renderer/canvas/canvas-renderer.ts
@@ -257,7 +257,7 @@ export class CanvasRenderer<N extends INodeBase, E extends IEdgeBase> extends Em
   }
 
   private _resize() {
-    const dpr = this._settings.devicePixelRatio || window.devicePixelRatio;
+    const dpr = this._settings.devicePixelRatio || window.devicePixelRatio || 1;
 
     const containerSize = this._container.getBoundingClientRect();
     this._canvas.style.width = `${containerSize.width}px`;

--- a/src/renderer/factory.ts
+++ b/src/renderer/factory.ts
@@ -1,28 +1,18 @@
 import { CanvasRenderer } from './canvas/canvas-renderer';
 import { IRenderer, IRendererSettings, RendererType } from './shared';
 import { WebGLRenderer } from './webgl/webgl-renderer';
-import { OrbError } from '../exceptions';
 import { INodeBase } from '../models/node';
 import { IEdgeBase } from '../models/edge';
 
 export class RendererFactory {
   static getRenderer<N extends INodeBase, E extends IEdgeBase>(
-    canvas: HTMLCanvasElement,
+    container: HTMLElement,
     type: RendererType = RendererType.CANVAS,
     settings?: Partial<IRendererSettings>,
   ): IRenderer<N, E> {
     if (type === RendererType.WEBGL) {
-      const context = canvas.getContext('webgl2');
-      if (!context) {
-        throw new OrbError('Failed to create WebGL context.');
-      }
-      return new WebGLRenderer<N, E>(context, settings);
+      return new WebGLRenderer<N, E>(container, settings);
     }
-
-    const context = canvas.getContext('2d');
-    if (!context) {
-      throw new OrbError('Failed to create Canvas context.');
-    }
-    return new CanvasRenderer<N, E>(context, settings);
+    return new CanvasRenderer<N, E>(container, settings);
   }
 }

--- a/src/renderer/shared.ts
+++ b/src/renderer/shared.ts
@@ -17,6 +17,7 @@ export enum RenderEventType {
 }
 
 export interface IRendererSettings {
+  devicePixelRatio: number | null;
   fps: number;
   minZoom: number;
   maxZoom: number;
@@ -54,15 +55,12 @@ export interface IRenderer<N extends INodeBase, E extends IEdgeBase> extends IEm
   get isInitiallyRendered(): boolean;
 
   getSettings(): IRendererSettings;
-
   setSettings(settings: Partial<IRendererSettings>): void;
 
   render(graph: IGraph<N, E>): void;
-
   reset(): void;
 
   getFitZoomTransform(graph: IGraph<N, E>): ZoomTransform;
-
   getSimulationPosition(canvasPoint: IPosition): IPosition;
 
   /**
@@ -78,6 +76,7 @@ export interface IRenderer<N extends INodeBase, E extends IEdgeBase> extends IEm
 }
 
 export const DEFAULT_RENDERER_SETTINGS: IRendererSettings = {
+  devicePixelRatio: null,
   fps: 60,
   minZoom: 0.25,
   maxZoom: 8,

--- a/src/renderer/shared.ts
+++ b/src/renderer/shared.ts
@@ -11,6 +11,7 @@ export enum RendererType {
 }
 
 export enum RenderEventType {
+  RESIZE = 'resize',
   RENDER_START = 'render-start',
   RENDER_END = 'render-end',
 }
@@ -27,6 +28,7 @@ export interface IRendererSettings {
   contextAlphaOnEvent: number;
   contextAlphaOnEventIsEnabled: boolean;
   backgroundColor: Color | string | null;
+  areCollapsedContainerDimensionsAllowed: boolean;
 }
 
 export interface IRendererSettingsInit extends IRendererSettings {
@@ -34,19 +36,21 @@ export interface IRendererSettingsInit extends IRendererSettings {
 }
 
 export type RendererEvents = {
+  [RenderEventType.RESIZE]: undefined;
   [RenderEventType.RENDER_START]: undefined;
   [RenderEventType.RENDER_END]: { durationMs: number };
 };
 
 export interface IRenderer<N extends INodeBase, E extends IEdgeBase> extends IEmitter<RendererEvents> {
-  // Width and height of the canvas. Used for clearing.
-  width: number;
-  height: number;
-
   // Includes translation (pan) in the x and y direction
   // as well as scaling (level of zoom).
   transform: ZoomTransform;
 
+  // Width and height of the canvas
+  get width(): number;
+  get height(): number;
+  get container(): HTMLElement;
+  get canvas(): HTMLCanvasElement;
   get isInitiallyRendered(): boolean;
 
   getSettings(): IRendererSettings;
@@ -69,6 +73,8 @@ export interface IRenderer<N extends INodeBase, E extends IEdgeBase> extends IEm
   getSimulationViewRectangle(): IRectangle;
 
   translateOriginToCenter(): void;
+
+  destroy(): void;
 }
 
 export const DEFAULT_RENDERER_SETTINGS: IRendererSettings = {
@@ -83,6 +89,7 @@ export const DEFAULT_RENDERER_SETTINGS: IRendererSettings = {
   contextAlphaOnEvent: 0.3,
   contextAlphaOnEventIsEnabled: true,
   backgroundColor: null,
+  areCollapsedContainerDimensionsAllowed: false,
 };
 
 export const DEFAULT_RENDERER_WIDTH = 640;

--- a/src/utils/html.utils.ts
+++ b/src/utils/html.utils.ts
@@ -48,3 +48,13 @@ export const isCollapsedDimension = (dimension: string | null | undefined) => {
 
   return collapsedDimensionRegex.test(dimension);
 };
+
+export const appendCanvas = (container: HTMLElement): HTMLCanvasElement => {
+  const canvas = document.createElement('canvas');
+  canvas.style.position = 'absolute';
+  canvas.style.top = '0';
+  canvas.style.left = '0';
+
+  container.appendChild(canvas);
+  return canvas;
+};

--- a/src/utils/html.utils.ts
+++ b/src/utils/html.utils.ts
@@ -17,7 +17,7 @@ export const setupContainer = (container: HTMLElement, areCollapsedDimensionsAll
         "[Orb] The graph container element and its parent don't have defined width properties.",
         'If you are using percentage values,',
         'please make sure that the parent element of the graph container has a defined position and width.',
-        "Setting the width of the graph container to an arbirtrary value of '400px'...",
+        "Setting the width of the graph container to an arbitrary value of '400px'...",
       );
     } else {
       console.warn("[Orb] The graph container element doesn't have defined width. Setting width to 100%...");
@@ -54,7 +54,32 @@ export const appendCanvas = (container: HTMLElement): HTMLCanvasElement => {
   canvas.style.position = 'absolute';
   canvas.style.top = '0';
   canvas.style.left = '0';
-
   container.appendChild(canvas);
   return canvas;
+};
+
+export type IObserveDPRCallback = (devicePixelRatio: number) => void;
+export type IObserveDPRUnsubscribe = () => void;
+
+export const observeDevicePixelRatioChanges = (callback: IObserveDPRCallback): IObserveDPRUnsubscribe => {
+  let currentDpr = window.devicePixelRatio;
+  let unsubscribe: IObserveDPRUnsubscribe = () => {
+    return;
+  };
+
+  const listenForDPRChanges = () => {
+    unsubscribe();
+
+    const media = matchMedia(`(resolution: ${currentDpr}dppx)`);
+    media.addEventListener('change', listenForDPRChanges);
+    unsubscribe = () => media.removeEventListener('change', listenForDPRChanges);
+
+    if (window.devicePixelRatio !== currentDpr) {
+      currentDpr = window.devicePixelRatio;
+      callback(currentDpr);
+    }
+  };
+
+  listenForDPRChanges();
+  return () => unsubscribe();
 };


### PR DESCRIPTION
The following PR adds support for automatic and manual handling of `devicePixelRatio`. More information about `devicePixelRatio` can be found here: https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio

There are two modes: Automatic and Manual.

*Automatic `devicePixelRatio` handler (default)*
The default behavior is the automatic handler of the `devicePixelRatio` value and changes (e.g. user drags a view from one display to another with a different DPR value). The automatic handler is turned on when the settings value `render.devicePixelRatio` equals to `null`.

*Manual `devicePixelRatio` handler*
If you want to manually handle the `devicePixelRatio` values, just set the settings value `render.devicePixelRatio` to a numeric DPR value. Orb will stop listening for DPR changes then.

This fixes issue #19. 
