### PR TITLE
New: Added support for context menu events

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -31,6 +31,9 @@ export enum OrbEventType {
   NODE_DRAG_START = 'node-drag-start',
   NODE_DRAG = 'node-drag',
   NODE_DRAG_END = 'node-drag-end',
+  NODE_RIGHT_CLICK = 'node-right-click',
+  EDGE_RIGHT_CLICK = 'edge-right-click',
+  CANVAS_RIGHT_CLICK = 'canvas-right-click',
 }
 ```
 

--- a/examples/example-graph-events.html
+++ b/examples/example-graph-events.html
@@ -113,6 +113,22 @@
       console.log('Event: edge-click', event);
       output.innerHTML = `Edge with id <b>${event.edge.data.id}</b> clicked!`;
     });
+
+    orb.events.on(Orb.OrbEventType.NODE_RIGHT_CLICK, (data) => {
+      data.event.preventDefault();
+      console.log("Node Right Clicked", data);
+    })
+
+    orb.events.on(Orb.OrbEventType.EDGE_RIGHT_CLICK, (data) => {
+      data.event.preventDefault();
+      console.log("Edge Right Clicked", data);
+    })
+
+    orb.events.on(Orb.OrbEventType.CANVAS_RIGHT_CLICK, (data) => {
+      data.event.preventDefault();
+      console.log("Canvas Right Clicked", data);
+    })
+
   </script>
 </body>
 </html>

--- a/examples/example-graph-events.html
+++ b/examples/example-graph-events.html
@@ -116,17 +116,22 @@
 
     orb.events.on(Orb.OrbEventType.NODE_RIGHT_CLICK, (data) => {
       data.event.preventDefault();
-      console.log("Node Right Clicked", data);
+      console.log("Event: node-right-click", data);
+      output.innerHTML = `<b>${data.node.data.label}</b> right clicked!`;
     })
 
     orb.events.on(Orb.OrbEventType.EDGE_RIGHT_CLICK, (data) => {
       data.event.preventDefault();
-      console.log("Edge Right Clicked", data);
+      console.log("Event: edge-right-click", data);
+      output.innerHTML = `Edge with id <b>${data.edge.data.id}</b> right clicked!`;
     })
 
-    orb.events.on(Orb.OrbEventType.CANVAS_RIGHT_CLICK, (data) => {
+    orb.events.on(Orb.OrbEventType.MOUSE_RIGHT_CLICK, (data) => {
       data.event.preventDefault();
-      console.log("Canvas Right Clicked", data);
+      console.log("Event: mouse-right-click (canvas)", data);
+      if (!data.subject) {
+        output.innerHTML = `Canvas right clicked!`;
+      }
     })
 
   </script>

--- a/src/events.ts
+++ b/src/events.ts
@@ -26,7 +26,7 @@ export enum OrbEventType {
   NODE_DRAG_END = 'node-drag-end',
   NODE_RIGHT_CLICK = 'node-right-click',
   EDGE_RIGHT_CLICK = 'edge-right-click',
-  CANVAS_RIGHT_CLICK = 'canvas-right-click',
+  MOUSE_RIGHT_CLICK = 'mouse-right-click',
 }
 
 export interface IOrbEventDuration {
@@ -88,5 +88,5 @@ export class OrbEmitter<N extends INodeBase, E extends IEdgeBase> extends Emitte
   [OrbEventType.NODE_DRAG_END]: IOrbEventMouseNodeEvent<N, E> & IOrbEventMouseMoveEvent;
   [OrbEventType.NODE_RIGHT_CLICK]: IOrbEventMouseNodeEvent<N, E> & IOrbEventMouseClickEvent;
   [OrbEventType.EDGE_RIGHT_CLICK]: IOrbEventMouseEdgeEvent<N, E> & IOrbEventMouseClickEvent;
-  [OrbEventType.CANVAS_RIGHT_CLICK]: IOrbEventMouseClickEvent;
+  [OrbEventType.MOUSE_RIGHT_CLICK]:  IOrbEventMouseEvent<N, E> & IOrbEventMouseClickEvent;
 }> {}

--- a/src/events.ts
+++ b/src/events.ts
@@ -24,6 +24,9 @@ export enum OrbEventType {
   NODE_DRAG_START = 'node-drag-start',
   NODE_DRAG = 'node-drag',
   NODE_DRAG_END = 'node-drag-end',
+  NODE_RIGHT_CLICK = 'node-right-click',
+  EDGE_RIGHT_CLICK = 'edge-right-click',
+  CANVAS_RIGHT_CLICK = 'canvas-right-click',
 }
 
 export interface IOrbEventDuration {
@@ -83,4 +86,7 @@ export class OrbEmitter<N extends INodeBase, E extends IEdgeBase> extends Emitte
   [OrbEventType.NODE_DRAG_START]: IOrbEventMouseNodeEvent<N, E> & IOrbEventMouseMoveEvent;
   [OrbEventType.NODE_DRAG]: IOrbEventMouseNodeEvent<N, E> & IOrbEventMouseMoveEvent;
   [OrbEventType.NODE_DRAG_END]: IOrbEventMouseNodeEvent<N, E> & IOrbEventMouseMoveEvent;
+  [OrbEventType.NODE_RIGHT_CLICK]: IOrbEventMouseNodeEvent<N, E> & IOrbEventMouseClickEvent;
+  [OrbEventType.EDGE_RIGHT_CLICK]: IOrbEventMouseEdgeEvent<N, E> & IOrbEventMouseClickEvent;
+  [OrbEventType.CANVAS_RIGHT_CLICK]: IOrbEventMouseClickEvent;
 }> {}

--- a/src/models/strategy.ts
+++ b/src/models/strategy.ts
@@ -12,6 +12,7 @@ export interface IEventStrategyResponse<N extends INodeBase, E extends IEdgeBase
 export interface IEventStrategy<N extends INodeBase, E extends IEdgeBase> {
   onMouseClick: ((graph: IGraph<N, E>, point: IPosition) => IEventStrategyResponse<N, E>) | null;
   onMouseMove: ((graph: IGraph<N, E>, point: IPosition) => IEventStrategyResponse<N, E>) | null;
+  onMouseRightClick: ((graph: IGraph<N, E>, point: IPosition) => IEventStrategyResponse<N, E>) | null;
 }
 
 export const getDefaultEventStrategy = <N extends INodeBase, E extends IEdgeBase>(): IEventStrategy<N, E> => {
@@ -73,6 +74,31 @@ class DefaultEventStrategy<N extends INodeBase, E extends IEdgeBase> implements 
     }
 
     return { isStateChanged: false };
+  }
+
+  onMouseRightClick(graph: IGraph<N, E>, point: IPosition): IEventStrategyResponse<N, E> {
+    const node = graph.getNearestNode(point);
+    if (node) {
+      selectNode(graph, node);
+      return {
+        isStateChanged: true,
+        changedSubject: node,
+      };
+    }
+
+    const edge = graph.getNearestEdge(point);
+    if (edge) {
+      selectEdge(graph, edge);
+      return {
+        isStateChanged: true,
+        changedSubject: edge,
+      };
+    }
+
+    const { changedCount } = unselectAll(graph);
+    return {
+      isStateChanged: changedCount > 0,
+    };
   }
 }
 

--- a/src/views/default-view.ts
+++ b/src/views/default-view.ts
@@ -115,7 +115,8 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
       )
       .call(this._d3Zoom)
       .on('click', this.mouseClicked)
-      .on('mousemove', this.mouseMoved);
+      .on('mousemove', this.mouseMoved)
+      .on("contextmenu", this.mouseRightClicked);
 
     this._simulator = SimulatorFactory.getSimulator();
     this._simulator.on(SimulatorEventType.SIMULATION_START, () => {
@@ -384,6 +385,49 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
       }
     }
   };
+
+  mouseRightClicked = (event: PointerEvent) => {
+    // event.preventDefault();
+    const mousePoint = this.getCanvasMousePosition(event);
+    const simulationPoint = this._renderer.getSimulationPosition(mousePoint);
+
+    if (this._strategy.onMouseRightClick) {
+      const response = this._strategy.onMouseRightClick(this._graph, simulationPoint);
+      const subject = response.changedSubject;
+
+      
+      if (subject) {
+        if (isNode(subject)) {
+          this._events.emit(OrbEventType.NODE_RIGHT_CLICK, {
+            node: subject,
+            event,
+            localPoint: simulationPoint,
+            globalPoint: mousePoint,
+          });
+        }
+        if (isEdge(subject)) {
+          this._events.emit(OrbEventType.EDGE_RIGHT_CLICK, {
+            edge: subject,
+            event,
+            localPoint: simulationPoint,
+            globalPoint: mousePoint,
+          });
+        }
+      } else {
+        this._events.emit(OrbEventType.CANVAS_RIGHT_CLICK, {
+          event,
+          localPoint: simulationPoint,
+          globalPoint: mousePoint,
+        });
+      }
+
+      
+
+      // if (response.isStateChanged || response.changedSubject) {
+      //   this._renderer.render(this._graph);
+      // }
+    }
+  }
 
   private _initCanvas(): HTMLCanvasElement {
     const canvas = document.createElement('canvas');

--- a/src/views/default-view.ts
+++ b/src/views/default-view.ts
@@ -387,7 +387,6 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
   };
 
   mouseRightClicked = (event: PointerEvent) => {
-    // event.preventDefault();
     const mousePoint = this.getCanvasMousePosition(event);
     const simulationPoint = this._renderer.getSimulationPosition(mousePoint);
 
@@ -395,7 +394,6 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
       const response = this._strategy.onMouseRightClick(this._graph, simulationPoint);
       const subject = response.changedSubject;
 
-      
       if (subject) {
         if (isNode(subject)) {
           this._events.emit(OrbEventType.NODE_RIGHT_CLICK, {
@@ -413,19 +411,18 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
             globalPoint: mousePoint,
           });
         }
-      } else {
-        this._events.emit(OrbEventType.CANVAS_RIGHT_CLICK, {
-          event,
-          localPoint: simulationPoint,
-          globalPoint: mousePoint,
-        });
       }
 
-      
+      this._events.emit(OrbEventType.MOUSE_RIGHT_CLICK, {
+        subject,
+        event,
+        localPoint: simulationPoint,
+        globalPoint: mousePoint,
+      });
 
-      // if (response.isStateChanged || response.changedSubject) {
-      //   this._renderer.render(this._graph);
-      // }
+      if (response.isStateChanged || response.changedSubject) {
+        this._renderer.render(this._graph);
+      }
     }
   }
 

--- a/src/views/map-view.ts
+++ b/src/views/map-view.ts
@@ -277,22 +277,24 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
               globalPoint: containerPoint,
             });
           }
-        } else {
-          this._events.emit(OrbEventType.CANVAS_RIGHT_CLICK, {
-            event: event.originalEvent,
-            localPoint: point,
-            globalPoint: containerPoint,
-          });
         }
 
-        
+        this._events.emit(OrbEventType.MOUSE_RIGHT_CLICK, {
+          subject,
+          event: event.originalEvent,
+          localPoint: point,
+          globalPoint: containerPoint,
+        });
+
+
+
 
         if (response.isStateChanged) {
           this._renderer.render(this._graph);
         }
         return;
       }
-      if (this._strategy.onMouseClick) {
+      if (event.type === 'click' && this._strategy.onMouseClick) {
         const response = this._strategy.onMouseClick(this._graph, point);
         const subject = response.changedSubject;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,12 @@ const commonConfiguration = {
         }
       ]
     })
-  ]
+  ],
+  performance: {
+    hints: false,
+    maxEntrypointSize: 512000, // 500kb
+    maxAssetSize: 512000, // 500kb
+  },
 };
 
 const developmentConfiguration = {


### PR DESCRIPTION
This PR will add support for context menu events (mouse right click), the library exposes the 3 new events 
```
1. NODE_RIGHT_CLICK  :  Triggered when a node on the canvas is clicked
2. EDGE_RIGHT_CLICK : Triggered when an edge is clicked.
3. CANVAS_RIGHT_CLICK : Triggered when the canvas is clicked.
``` 

For example, to handle NODE_RIGHT_CLICK event we can use

```
orb.events.on(Orb.OrbEventType.NODE_RIGHT_CLICK, (data) => {
      data.event.preventDefault();
      console.log("Node Right Clicked", data);
})
```