### PR TITLE
New: Added support for double click events

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -33,7 +33,11 @@ export enum OrbEventType {
   NODE_DRAG_END = 'node-drag-end',
   NODE_RIGHT_CLICK = 'node-right-click',
   EDGE_RIGHT_CLICK = 'edge-right-click',
-  CANVAS_RIGHT_CLICK = 'canvas-right-click',
+  MOUSE_RIGHT_CLICK = 'mouse-right-click',
+  // DBL click events
+  NODE_DOUBLE_CLICK = 'node-double-click',
+  EDGE_DOUBLE_CLICK = 'edge-double-click',
+  MOUSE_DOUBLE_CLICK = 'mouse-double-click',  
 }
 ```
 

--- a/examples/example-graph-events.html
+++ b/examples/example-graph-events.html
@@ -134,6 +134,22 @@
       }
     })
 
+    orb.events.on(Orb.OrbEventType.NODE_DOUBLE_CLICK, (data) => {
+      console.log("Event: node-double-click", data);
+      output.innerHTML = `<b>${data.node.data.label}</b> double clicked!`;
+    })
+
+    orb.events.on(Orb.OrbEventType.EDGE_DOUBLE_CLICK, (data) => {
+      console.log("Event: edge-double-click", data);
+      output.innerHTML = `Edge with id <b>${data.edge.data.id}</b> double clicked!`;
+    })
+
+    orb.events.on(Orb.OrbEventType.MOUSE_DOUBLE_CLICK, (data) => {
+      console.log("Event: mouse-double-click (canvas)", data);
+      if (!data.subject) {
+        output.innerHTML = `Canvas double clicked!`;
+      }
+    })
   </script>
 </body>
 </html>

--- a/src/events.ts
+++ b/src/events.ts
@@ -30,7 +30,7 @@ export enum OrbEventType {
   // Double click events
   NODE_DOUBLE_CLICK = 'node-double-click',
   EDGE_DOUBLE_CLICK = 'edge-double-click',
-  MOUSE_DOUBLE_CLICK = 'mouse-double-click'
+  MOUSE_DOUBLE_CLICK = 'mouse-double-click',
 }
 
 export interface IOrbEventDuration {

--- a/src/events.ts
+++ b/src/events.ts
@@ -27,6 +27,10 @@ export enum OrbEventType {
   NODE_RIGHT_CLICK = 'node-right-click',
   EDGE_RIGHT_CLICK = 'edge-right-click',
   MOUSE_RIGHT_CLICK = 'mouse-right-click',
+  // Double click events
+  NODE_DOUBLE_CLICK = 'node-double-click',
+  EDGE_DOUBLE_CLICK = 'edge-double-click',
+  MOUSE_DOUBLE_CLICK = 'mouse-double-click'
 }
 
 export interface IOrbEventDuration {
@@ -89,4 +93,7 @@ export class OrbEmitter<N extends INodeBase, E extends IEdgeBase> extends Emitte
   [OrbEventType.NODE_RIGHT_CLICK]: IOrbEventMouseNodeEvent<N, E> & IOrbEventMouseClickEvent;
   [OrbEventType.EDGE_RIGHT_CLICK]: IOrbEventMouseEdgeEvent<N, E> & IOrbEventMouseClickEvent;
   [OrbEventType.MOUSE_RIGHT_CLICK]: IOrbEventMouseEvent<N, E> & IOrbEventMouseClickEvent;
+  [OrbEventType.NODE_DOUBLE_CLICK]: IOrbEventMouseNodeEvent<N, E> & IOrbEventMouseClickEvent;
+  [OrbEventType.EDGE_DOUBLE_CLICK]: IOrbEventMouseEdgeEvent<N, E> & IOrbEventMouseClickEvent;
+  [OrbEventType.MOUSE_DOUBLE_CLICK]: IOrbEventMouseEvent<N, E> & IOrbEventMouseClickEvent;
 }> {}

--- a/src/models/strategy.ts
+++ b/src/models/strategy.ts
@@ -13,6 +13,7 @@ export interface IEventStrategy<N extends INodeBase, E extends IEdgeBase> {
   onMouseClick: ((graph: IGraph<N, E>, point: IPosition) => IEventStrategyResponse<N, E>) | null;
   onMouseMove: ((graph: IGraph<N, E>, point: IPosition) => IEventStrategyResponse<N, E>) | null;
   onMouseRightClick: ((graph: IGraph<N, E>, point: IPosition) => IEventStrategyResponse<N, E>) | null;
+  onMouseDoubleClick: ((graph: IGraph<N, E>, point: IPosition) => IEventStrategyResponse<N, E>) | null;
 }
 
 export const getDefaultEventStrategy = <N extends INodeBase, E extends IEdgeBase>(): IEventStrategy<N, E> => {
@@ -77,6 +78,31 @@ class DefaultEventStrategy<N extends INodeBase, E extends IEdgeBase> implements 
   }
 
   onMouseRightClick(graph: IGraph<N, E>, point: IPosition): IEventStrategyResponse<N, E> {
+    const node = graph.getNearestNode(point);
+    if (node) {
+      selectNode(graph, node);
+      return {
+        isStateChanged: true,
+        changedSubject: node,
+      };
+    }
+
+    const edge = graph.getNearestEdge(point);
+    if (edge) {
+      selectEdge(graph, edge);
+      return {
+        isStateChanged: true,
+        changedSubject: edge,
+      };
+    }
+
+    const { changedCount } = unselectAll(graph);
+    return {
+      isStateChanged: changedCount > 0,
+    };
+  }
+
+  onMouseDoubleClick(graph: IGraph<N, E>, point: IPosition): IEventStrategyResponse<N, E> {
     const node = graph.getNearestNode(point);
     if (node) {
       selectNode(graph, node);

--- a/src/views/default-view.ts
+++ b/src/views/default-view.ts
@@ -116,7 +116,8 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
       .call(this._d3Zoom)
       .on('click', this.mouseClicked)
       .on('mousemove', this.mouseMoved)
-      .on('contextmenu', this.mouseRightClicked);
+      .on('contextmenu', this.mouseRightClicked)
+      .on('dblclick.zoom', this.mouseDoubleClicked);
 
     this._simulator = SimulatorFactory.getSimulator();
     this._simulator.on(SimulatorEventType.SIMULATION_START, () => {
@@ -414,6 +415,46 @@ export class DefaultView<N extends INodeBase, E extends IEdgeBase> implements IO
       }
 
       this._events.emit(OrbEventType.MOUSE_RIGHT_CLICK, {
+        subject,
+        event,
+        localPoint: simulationPoint,
+        globalPoint: mousePoint,
+      });
+
+      if (response.isStateChanged || response.changedSubject) {
+        this._renderer.render(this._graph);
+      }
+    }
+  };
+
+  mouseDoubleClicked = (event: PointerEvent) => {
+    const mousePoint = this.getCanvasMousePosition(event);
+    const simulationPoint = this._renderer.getSimulationPosition(mousePoint);
+
+    if (this._strategy.onMouseDoubleClick) {
+      const response = this._strategy.onMouseDoubleClick(this._graph, simulationPoint);
+      const subject = response.changedSubject;
+
+      if (subject) {
+        if (isNode(subject)) {
+          this._events.emit(OrbEventType.NODE_DOUBLE_CLICK, {
+            node: subject,
+            event,
+            localPoint: simulationPoint,
+            globalPoint: mousePoint,
+          });
+        }
+        if (isEdge(subject)) {
+          this._events.emit(OrbEventType.EDGE_DOUBLE_CLICK, {
+            edge: subject,
+            event,
+            localPoint: simulationPoint,
+            globalPoint: mousePoint,
+          });
+        }
+      }
+
+      this._events.emit(OrbEventType.MOUSE_DOUBLE_CLICK, {
         subject,
         event,
         localPoint: simulationPoint,

--- a/src/views/map-view.ts
+++ b/src/views/map-view.ts
@@ -252,7 +252,7 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
 
     // Leaflet doesn't have a valid type definition for click event
     // @ts-ignore
-    leaflet.on('click contextmenu', (event: ILeafletEvent<PointerEvent>) => {
+    leaflet.on('click contextmenu dblclick', (event: ILeafletEvent<PointerEvent>) => {
       const point: IPosition = { x: event.layerPoint.x, y: event.layerPoint.y };
       const containerPoint: IPosition = { x: event.containerPoint.x, y: event.containerPoint.y };
 
@@ -290,8 +290,7 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
           this._renderer.render(this._graph);
         }
         return;
-      }
-      if (event.type === 'click' && this._strategy.onMouseClick) {
+      } else if (event.type === 'click' && this._strategy.onMouseClick) {
         const response = this._strategy.onMouseClick(this._graph, point);
         const subject = response.changedSubject;
 
@@ -315,6 +314,39 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
         }
 
         this._events.emit(OrbEventType.MOUSE_CLICK, {
+          subject,
+          event: event.originalEvent,
+          localPoint: point,
+          globalPoint: containerPoint,
+        });
+
+        if (response.isStateChanged || response.changedSubject) {
+          this._renderer.render(this._graph);
+        }
+      } else if (event.type === 'dblclick' && this._strategy.onMouseDoubleClick) {
+        const response = this._strategy.onMouseDoubleClick(this._graph, point);
+        const subject = response.changedSubject;
+
+        if (subject) {
+          if (isNode(subject)) {
+            this._events.emit(OrbEventType.NODE_DOUBLE_CLICK, {
+              node: subject,
+              event: event.originalEvent,
+              localPoint: point,
+              globalPoint: containerPoint,
+            });
+          }
+          if (isEdge(subject)) {
+            this._events.emit(OrbEventType.EDGE_DOUBLE_CLICK, {
+              edge: subject,
+              event: event.originalEvent,
+              localPoint: point,
+              globalPoint: containerPoint,
+            });
+          }
+        }
+
+        this._events.emit(OrbEventType.MOUSE_DOUBLE_CLICK, {
           subject,
           event: event.originalEvent,
           localPoint: point,

--- a/src/views/map-view.ts
+++ b/src/views/map-view.ts
@@ -345,14 +345,17 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
               globalPoint: containerPoint,
             });
           }
-        } else {
-          this._events.emit(OrbEventType.MOUSE_DOUBLE_CLICK, {
-            subject,
-            event: event.originalEvent,
-            localPoint: point,
-            globalPoint: containerPoint,
-          });
-          // zoom in on double click
+        }
+        
+        this._events.emit(OrbEventType.MOUSE_DOUBLE_CLICK, {
+          subject,
+          event: event.originalEvent,
+          localPoint: point,
+          globalPoint: containerPoint,
+        });
+        
+        // zoom in on double click if no subject underneath
+        if (!subject) {
           const zoom = event.target._zoom + 1;
           event.target.setZoomAround(event.layerPoint, zoom);
         }

--- a/src/views/map-view.ts
+++ b/src/views/map-view.ts
@@ -197,7 +197,9 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
   }
 
   private _initLeaflet() {
-    const leaflet = L.map(this._map).setView([0, 0], this._settings.map.zoomLevel);
+    const leaflet = L.map(this._map, {
+      doubleClickZoom: false,
+    }).setView([0, 0], this._settings.map.zoomLevel);
 
     leaflet.on('zoomstart', () => {
       this._renderer.reset();
@@ -289,7 +291,6 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
         if (response.isStateChanged) {
           this._renderer.render(this._graph);
         }
-        return;
       } else if (event.type === 'click' && this._strategy.onMouseClick) {
         const response = this._strategy.onMouseClick(this._graph, point);
         const subject = response.changedSubject;
@@ -344,14 +345,17 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
               globalPoint: containerPoint,
             });
           }
+        } else {
+          this._events.emit(OrbEventType.MOUSE_DOUBLE_CLICK, {
+            subject,
+            event: event.originalEvent,
+            localPoint: point,
+            globalPoint: containerPoint,
+          });
+          // zoom in on double click
+          const zoom = event.target._zoom + 1;
+          event.target.setZoomAround(event.layerPoint, zoom);
         }
-
-        this._events.emit(OrbEventType.MOUSE_DOUBLE_CLICK, {
-          subject,
-          event: event.originalEvent,
-          localPoint: point,
-          globalPoint: containerPoint,
-        });
 
         if (response.isStateChanged || response.changedSubject) {
           this._renderer.render(this._graph);

--- a/src/views/map-view.ts
+++ b/src/views/map-view.ts
@@ -346,14 +346,14 @@ export class MapView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
             });
           }
         }
-        
+
         this._events.emit(OrbEventType.MOUSE_DOUBLE_CLICK, {
           subject,
           event: event.originalEvent,
           localPoint: point,
           globalPoint: containerPoint,
         });
-        
+
         // zoom in on double click if no subject underneath
         if (!subject) {
           const zoom = event.target._zoom + 1;


### PR DESCRIPTION
This PR will add support for double click events, the library exposes the 3 new events 
```
1. NODE_DOUBLE_CLICK :  Triggered when a node on the canvas is double clicked
2. EDGE_DOUBLE_CLICK : Triggered when an edge is double clicked.
3. MOUSE_DOUBLE_CLICK: Triggered when the canvas is double clicked.
``` 

For example, to handle NODE_DOUBLE_CLICK event we can use

```
orb.events.on(Orb.OrbEventType.NODE_DOUBLE_CLICK , (data) => {
      console.log("Node Double Clicked", data);
})
```