### PR TITLE
New: Add zIndex style property

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -46,6 +46,7 @@ the following properties:
 | `shape`               | NodeShapeType       | Node shape enum. Possible values are: `CIRCLE`, `DOT` (same as circle), `SQUARE`, `DIAMOND`, `TRIANGLE`, `TRIANGLE_DOWN`, `STAR`, `HEXAGON`. Default is `NodeShapeEnum.CIRCLE`. |
 | `size`                | number              | Node size (usually the radius). The default is `5`. |
 | `mass`                | number              | Node mass. _(Currently not used)_               |
+| `zIndex`              | number              | Specifies the stack order of an element during rendering. The default is `0`. |
 
 ## Shape enumeration
 
@@ -136,6 +137,7 @@ style properties:
 | `width`               | number              | Edge line width. If the width is `0`, the edge won't be drawn. The default is `0.3`. |
 | `widthHover`          | number              | Edge line width on mouse hover event. If not defined `width` is used. |
 | `widthSelected`       | number              | Edge line width on mouse click event. If not defined `width` is used. |
+| `zIndex`              | number              | Specifies the stack order of an element during rendering. The default is `0`. |
 
 ## Default style values
 

--- a/examples/example-custom-styled-graph.html
+++ b/examples/example-custom-styled-graph.html
@@ -63,6 +63,7 @@
             ...basicStyle,
             size: 10,
             color: '#00FF2B',
+            zIndex: 1,
           };
         }
 

--- a/src/models/edge.ts
+++ b/src/models/edge.ts
@@ -45,6 +45,7 @@ export type IEdgeStyle = Partial<{
   width: number;
   widthHover: number;
   widthSelected: number;
+  zIndex: number;
 }>;
 
 export interface IEdgeData<N extends INodeBase, E extends IEdgeBase> {

--- a/src/models/node.ts
+++ b/src/models/node.ts
@@ -58,6 +58,7 @@ export type INodeStyle = Partial<{
   shape: NodeShapeType;
   size: number;
   mass: number;
+  zIndex: number;
 }>;
 
 export interface INodeData<N extends INodeBase> {

--- a/src/renderer/canvas/canvas-renderer.ts
+++ b/src/renderer/canvas/canvas-renderer.ts
@@ -132,8 +132,8 @@ export class CanvasRenderer<N extends INodeBase, E extends IEdgeBase> extends Em
       this._context.fillRect(0, 0, this.width, this.height);
     }
 
-    this.drawObjects(graph.getEdges());
-    this.drawObjects(graph.getNodes());
+    this.drawObjects(sortObjectsByZIndex(graph.getEdges()));
+    this.drawObjects(sortObjectsByZIndex(graph.getNodes()));
 
     this._context.restore();
     this.emit(RenderEventType.RENDER_END, { durationMs: Date.now() - renderStartedAt });
@@ -273,3 +273,22 @@ export class CanvasRenderer<N extends INodeBase, E extends IEdgeBase> extends Em
     this._isOriginCentered = true;
   }
 }
+
+const sortObjectsByZIndex = <N extends INodeBase, E extends IEdgeBase>(
+  objects: (INode<N, E> | IEdge<N, E>)[],
+): (INode<N, E> | IEdge<N, E>)[] => {
+  // Skip unnecessary sorting if there are no zIndexes set
+  let hasZIndex = false;
+  for (let i = 0; i < objects.length; i++) {
+    if (objects[i].style.zIndex) {
+      hasZIndex = true;
+      break;
+    }
+  }
+
+  if (hasZIndex) {
+    objects.sort((a, b) => (a.style.zIndex ?? 0) - (b.style.zIndex ?? 0));
+  }
+
+  return objects;
+};

--- a/src/renderer/canvas/canvas-renderer.ts
+++ b/src/renderer/canvas/canvas-renderer.ts
@@ -132,8 +132,8 @@ export class CanvasRenderer<N extends INodeBase, E extends IEdgeBase> extends Em
       this._context.fillRect(0, 0, this.width, this.height);
     }
 
-    this.drawObjects(sortObjectsByZIndex(graph.getEdges()));
-    this.drawObjects(sortObjectsByZIndex(graph.getNodes()));
+    this.drawObjects(graph.getEdges());
+    this.drawObjects(graph.getNodes());
 
     this._context.restore();
     this.emit(RenderEventType.RENDER_END, { durationMs: Date.now() - renderStartedAt });
@@ -273,22 +273,3 @@ export class CanvasRenderer<N extends INodeBase, E extends IEdgeBase> extends Em
     this._isOriginCentered = true;
   }
 }
-
-const sortObjectsByZIndex = <N extends INodeBase, E extends IEdgeBase>(
-  objects: (INode<N, E> | IEdge<N, E>)[],
-): (INode<N, E> | IEdge<N, E>)[] => {
-  // Skip unnecessary sorting if there are no zIndexes set
-  let hasZIndex = false;
-  for (let i = 0; i < objects.length; i++) {
-    if (objects[i].style.zIndex) {
-      hasZIndex = true;
-      break;
-    }
-  }
-
-  if (hasZIndex) {
-    objects.sort((a, b) => (a.style.zIndex ?? 0) - (b.style.zIndex ?? 0));
-  }
-
-  return objects;
-};

--- a/src/utils/entity.utils.ts
+++ b/src/utils/entity.utils.ts
@@ -1,0 +1,157 @@
+/**
+ * A key-value model that keeps an order of the elements by
+ * the input sort function.
+ *
+ * Insipration by NgRx/EntityState: https://github.com/ngrx/platform
+ */
+export interface IEntityState<K, V> {
+  getOne(id: K): V | undefined;
+  getMany(ids: K[], options?: Partial<IEntityGetOptions<V>>): V[];
+  getAll(options?: Partial<IEntityGetOptions<V>>): V[];
+  setOne(entity: V): void;
+  setMany(entities: V[]): void;
+  removeMany(ids: K[]): void;
+  removeAll(): void;
+  sort(): void;
+  size: number;
+}
+
+export interface IEntityDefinition<K, V> {
+  getId: (entity: V) => K;
+  sortBy?: (entity1: V, entity2: V) => number;
+}
+
+export interface IEntityGetOptions<V> {
+  filterBy: (entity: V) => boolean;
+}
+
+export class EntityState<K, V> implements IEntityState<K, V> {
+  private ids: K[] = [];
+  private entityById: Map<K, V> = new Map<K, V>();
+  private getId: IEntityDefinition<K, V>['getId'];
+  private sortBy?: IEntityDefinition<K, V>['sortBy'];
+
+  constructor(definition: IEntityDefinition<K, V>) {
+    this.getId = definition.getId;
+    this.sortBy = definition.sortBy;
+  }
+
+  getOne(id: K): V | undefined {
+    return this.entityById.get(id);
+  }
+
+  getMany(ids: K[], options?: Partial<IEntityGetOptions<V>>): V[] {
+    const entities: V[] = [];
+    for (let i = 0; i < ids.length; i++) {
+      const entity = this.getOne(ids[i]);
+      if (entity === undefined) {
+        continue;
+      }
+
+      if (options?.filterBy && !options.filterBy(entity)) {
+        continue;
+      }
+
+      entities.push(entity);
+    }
+
+    if (this.sortBy) {
+      entities.sort(this.sortBy);
+    }
+    return entities;
+  }
+
+  getAll(options?: Partial<IEntityGetOptions<V>>): V[] {
+    const entities: V[] = [];
+    for (let i = 0; i < this.ids.length; i++) {
+      const entity = this.getOne(this.ids[i]);
+      if (entity === undefined) {
+        continue;
+      }
+
+      if (options?.filterBy && !options.filterBy(entity)) {
+        continue;
+      }
+
+      entities.push(entity);
+    }
+    return entities;
+  }
+
+  setOne(entity: V): void {
+    const id = this.getId(entity);
+    const isNewEntity = !this.entityById.has(id);
+
+    this.entityById.set(id, entity);
+    if (isNewEntity) {
+      this.ids.push(id);
+      this.sort();
+    }
+  }
+
+  setMany(entities: V[]): void {
+    if (this.sortBy) {
+      entities.sort(this.sortBy);
+    }
+
+    const newIds: K[] = [];
+    for (let i = 0; i < entities.length; i++) {
+      const entityId = this.getId(entities[i]);
+      if (!this.entityById.has(entityId)) {
+        newIds.push(entityId);
+      }
+      this.entityById.set(entityId, entities[i]);
+    }
+
+    this.ids = this.ids.concat(newIds);
+    this.sort();
+  }
+
+  removeMany(ids: K[]): void {
+    const uniqueRemovedIds = new Set<K>(ids);
+
+    const newIds: K[] = [];
+    for (let i = 0; i < this.ids.length; i++) {
+      if (!uniqueRemovedIds.has(this.ids[i])) {
+        newIds.push(this.ids[i]);
+      }
+    }
+
+    this.ids = newIds;
+    for (let i = 0; i < ids.length; i++) {
+      this.entityById.delete(ids[i]);
+    }
+  }
+
+  removeAll(): void {
+    this.ids = [];
+    this.entityById.clear();
+  }
+
+  sort() {
+    if (!this.sortBy) {
+      return;
+    }
+
+    this.ids.sort((id1, id2) => {
+      // Typescript can't see the guard in the upper context
+      if (!this.sortBy) {
+        return 0;
+      }
+
+      const entity1 = this.getOne(id1);
+      const entity2 = this.getOne(id2);
+
+      // Should never happen
+      if (entity1 === undefined || entity2 === undefined) {
+        return 0;
+      }
+
+      return this.sortBy(entity1, entity2);
+    });
+  }
+
+  get size(): number {
+    return this.entityById.size;
+  }
+}

--- a/test/utils/entity.utils.spec.ts
+++ b/test/utils/entity.utils.spec.ts
@@ -1,0 +1,253 @@
+import { EntityState } from '../../src/utils/entity.utils';
+
+interface ITestState {
+  id: number;
+  name: string;
+  value?: number;
+}
+
+describe('entity.utils', () => {
+  describe('EntityState', () => {
+    describe('without sort', () => {
+      const items: ITestState[] = [
+        { id: 1, name: 'One' },
+        { id: 2, name: 'Two' },
+        { id: 3, name: 'Three' },
+      ];
+
+      const createDefaultState = (initialItems?: ITestState[]) => {
+        const state = new EntityState<number, ITestState>({
+          getId: (item) => item.id,
+        });
+
+        if (initialItems) {
+          state.setMany(initialItems);
+        }
+
+        return state;
+      };
+
+      test('should have size zero on init', () => {
+        const state = createDefaultState();
+
+        expect(state.size).toEqual(0);
+      });
+
+      test('should create entities one by one', () => {
+        const state = createDefaultState();
+        items.forEach((item) => {
+          state.setOne(item);
+        });
+
+        expect(state.size).toEqual(items.length);
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i];
+          expect(state.getOne(item.id)?.name).toEqual(item.name);
+        }
+        expect(state.getAll()).toEqual(items);
+        expect(state.getMany(items.map((i) => i.id))).toEqual(items);
+      });
+
+      test('should create multiple entities in a single call', () => {
+        const state = createDefaultState();
+        state.setMany(items);
+
+        expect(state.size).toEqual(items.length);
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i];
+          expect(state.getOne(item.id)?.name).toEqual(item.name);
+        }
+        expect(state.getAll()).toEqual(items);
+        expect(state.getMany(items.map((i) => i.id))).toEqual(items);
+      });
+
+      test('should overwrite entities with one single id one by one', () => {
+        const state = new EntityState<number, ITestState>({
+          getId: () => 1,
+        });
+        items.forEach((item) => {
+          state.setOne(item);
+        });
+
+        expect(state.size).toEqual(1);
+        expect(state.getOne(1)?.name).toEqual(items[items.length - 1].name);
+        expect(state.getOne(2)).toBeUndefined();
+        expect(state.getOne(3)).toBeUndefined();
+      });
+
+      test('should overwrite entities with one single id in a single call', () => {
+        const state = new EntityState<number, ITestState>({
+          getId: () => 1,
+        });
+        state.setMany(items);
+
+        expect(state.size).toEqual(1);
+        expect(state.getOne(1)?.name).toEqual(items[items.length - 1].name);
+        expect(state.getOne(2)).toBeUndefined();
+        expect(state.getOne(3)).toBeUndefined();
+      });
+
+      test('should return empty array for missing ids', () => {
+        const state = createDefaultState(items);
+        const maxId = Math.max(...items.map((item) => item.id));
+
+        expect(state.getMany([maxId + 1, maxId + 2, maxId + 3])).toEqual([]);
+      });
+
+      test('should return filtered items by custom function', () => {
+        const state = createDefaultState(items);
+        const filterBy = (item: ITestState) => item.name.length > 3;
+        const filteredItems = items.filter(filterBy);
+
+        expect(state.getAll({ filterBy })).toEqual(filteredItems);
+      });
+
+      test('should remove found distinct entities', () => {
+        const state = createDefaultState(items);
+        const removeIds = [5, 2, 4, 2];
+        const existingItems = items.filter((item) => !removeIds.includes(item.id));
+        state.removeMany(removeIds);
+
+        expect(state.size).toEqual(existingItems.length);
+        for (let i = 0; i < existingItems.length; i++) {
+          const item = existingItems[i];
+          expect(state.getOne(item.id)?.name).toEqual(item.name);
+        }
+        expect(state.getAll()).toEqual(existingItems);
+        expect(state.getMany(existingItems.map((i) => i.id))).toEqual(existingItems);
+      });
+
+      test('should remove all', () => {
+        const state = createDefaultState(items);
+        state.removeAll();
+
+        expect(state.size).toEqual(0);
+      });
+    });
+
+    describe('with sort', () => {
+      const items: ITestState[] = [
+        { id: 1, name: 'One' },
+        { id: 2, name: 'Two', value: 10 },
+        { id: 3, name: 'Three', value: 1 },
+        { id: 4, name: 'Four' },
+        { id: 5, name: 'Five', value: 1 },
+      ];
+      const sortBy = (item1: ITestState, item2: ITestState) => (item1.value ?? 0) - (item2.value ?? 0);
+      const sortedItems = items.sort(sortBy);
+
+      const createDefaultState = (initialItems?: ITestState[]) => {
+        const state = new EntityState<number, ITestState>({
+          getId: (item) => item.id,
+          sortBy,
+        });
+
+        if (initialItems) {
+          state.setMany(initialItems);
+        }
+
+        return state;
+      };
+
+      test('should have size zero on init', () => {
+        const state = createDefaultState();
+
+        expect(state.size).toEqual(0);
+      });
+
+      test('should create entities one by one', () => {
+        const state = createDefaultState();
+        items.forEach((item) => {
+          state.setOne(item);
+        });
+
+        expect(state.size).toEqual(items.length);
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i];
+          expect(state.getOne(item.id)?.name).toEqual(item.name);
+        }
+        expect(state.getAll()).toEqual(sortedItems);
+        expect(state.getMany(items.map((i) => i.id))).toEqual(sortedItems);
+      });
+
+      test('should create multiple entities in a single call', () => {
+        const state = createDefaultState();
+        state.setMany(items);
+
+        expect(state.size).toEqual(items.length);
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i];
+          expect(state.getOne(item.id)?.name).toEqual(item.name);
+        }
+        expect(state.getAll()).toEqual(sortedItems);
+        expect(state.getMany(items.map((i) => i.id))).toEqual(sortedItems);
+      });
+
+      test('should overwrite entities with one single id one by one', () => {
+        const state = new EntityState<number, ITestState>({
+          getId: () => 1,
+          sortBy,
+        });
+        items.forEach((item) => {
+          state.setOne(item);
+        });
+
+        expect(state.size).toEqual(1);
+        expect(state.getOne(1)?.name).toEqual(items[items.length - 1].name);
+        expect(state.getOne(2)).toBeUndefined();
+        expect(state.getOne(3)).toBeUndefined();
+      });
+
+      test('should overwrite entities with one single id in a single call', () => {
+        const state = new EntityState<number, ITestState>({
+          getId: () => 1,
+          sortBy,
+        });
+        const finalItem = sortedItems[sortedItems.length - 1];
+        state.setMany(items);
+
+        expect(state.size).toEqual(1);
+        expect(state.getOne(1)?.name).toEqual(finalItem.name);
+        expect(state.getOne(2)).toBeUndefined();
+        expect(state.getOne(3)).toBeUndefined();
+      });
+
+      test('should return empty array for missing ids', () => {
+        const state = createDefaultState(items);
+        const maxId = Math.max(...items.map((item) => item.id));
+
+        expect(state.getMany([maxId + 1, maxId + 2, maxId + 3])).toEqual([]);
+      });
+
+      test('should return filtered items by custom function', () => {
+        const state = createDefaultState(items);
+        const filterBy = (item: ITestState) => item.name.length > 3;
+        const filteredItems = sortedItems.filter(filterBy);
+
+        expect(state.getAll({ filterBy })).toEqual(filteredItems);
+      });
+
+      test('should remove found distinct entities', () => {
+        const state = createDefaultState(items);
+        const removeIds = [7, 2, 4, 2, 1, 1];
+        const existingItems = sortedItems.filter((item) => !removeIds.includes(item.id));
+        state.removeMany(removeIds);
+
+        expect(state.size).toEqual(existingItems.length);
+        for (let i = 0; i < existingItems.length; i++) {
+          const item = existingItems[i];
+          expect(state.getOne(item.id)?.name).toEqual(item.name);
+        }
+        expect(state.getAll()).toEqual(existingItems);
+        expect(state.getMany(existingItems.map((i) => i.id))).toEqual(existingItems);
+      });
+
+      test('should remove all', () => {
+        const state = createDefaultState(items);
+        state.removeAll();
+
+        expect(state.size).toEqual(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Additional `zIndex` property on nodes and edges that act similar to CSS z-index. If set on any of the nodes, the zIndex property value will be used as a stack order when rendering nodes/edges.

An example "Custom styled graph" has been updated where the first node has the highest zIndex value.

![Screenshot 2023-05-01 at 12 25 16](https://user-images.githubusercontent.com/2602830/235441601-eb8206ae-85d6-4918-abf6-6fbe26a643e2.png)
