### PR TITLE
New: Add canvas background color

### DIFF
--- a/docs/view-default.md
+++ b/docs/view-default.md
@@ -79,6 +79,7 @@ interface IDefaultViewSettings {
     shadowOnEventIsEnabled: boolean;
     contextAlphaOnEvent: number;
     contextAlphaOnEventIsEnabled: boolean;
+    backgroundColor: Color | string | null;
   };
   // Other default view parameters
   zoomFitTransitionMs: number;
@@ -143,6 +144,7 @@ const defaultSettings = {
     shadowOnEventIsEnabled: true,
     contextAlphaOnEvent: 0.3,
     contextAlphaOnEventIsEnabled: true,
+    backgroundColor: null,
   },
   zoomFitTransitionMs: 200,
   isOutOfBoundsDragEnabled: false,

--- a/docs/view-map.md
+++ b/docs/view-map.md
@@ -132,6 +132,7 @@ interface IMapViewSettings {
     shadowOnEventIsEnabled: boolean;
     contextAlphaOnEvent: number;
     contextAlphaOnEventIsEnabled: boolean;
+    backgroundColor: Color | string | null;
   };
   // Other map view parameters
   map: {
@@ -157,6 +158,7 @@ const defaultSettings = {
     shadowOnEventIsEnabled: true,
     contextAlphaOnEvent: 0.3,
     contextAlphaOnEventIsEnabled: true,
+    backgroundColor: null,
   },
   map: {
     zoomLevel: 2, // Default map zoom level

--- a/examples/example-custom-styled-graph.html
+++ b/examples/example-custom-styled-graph.html
@@ -43,6 +43,11 @@
     ]
 
     const orb = new Orb.Orb(container);
+    orb.view.setSettings({
+      render: {
+        backgroundColor: '#DDDDDD',
+      },
+    });
 
     // Assign a basic style
     orb.data.setDefaultStyle({

--- a/src/renderer/canvas/canvas-renderer.ts
+++ b/src/renderer/canvas/canvas-renderer.ts
@@ -98,6 +98,10 @@ export class CanvasRenderer<N extends INodeBase, E extends IEdgeBase> extends Em
 
     // Clear drawing.
     this._context.clearRect(0, 0, this.width, this.height);
+    if (this._settings.backgroundColor) {
+      this._context.fillStyle = this._settings.backgroundColor.toString();
+      this._context.fillRect(0, 0, this.width, this.height);
+    }
     this._context.save();
 
     if (DEBUG) {

--- a/src/renderer/shared.ts
+++ b/src/renderer/shared.ts
@@ -1,5 +1,5 @@
 import { ZoomTransform } from 'd3-zoom';
-import { IPosition, IRectangle } from '../common';
+import { Color, IPosition, IRectangle } from '../common';
 import { INodeBase } from '../models/node';
 import { IEdgeBase } from '../models/edge';
 import { IGraph } from '../models/graph';
@@ -26,6 +26,7 @@ export interface IRendererSettings {
   shadowOnEventIsEnabled: boolean;
   contextAlphaOnEvent: number;
   contextAlphaOnEventIsEnabled: boolean;
+  backgroundColor: Color | string | null;
 }
 
 export interface IRendererSettingsInit extends IRendererSettings {
@@ -81,6 +82,7 @@ export const DEFAULT_RENDERER_SETTINGS: IRendererSettings = {
   shadowOnEventIsEnabled: true,
   contextAlphaOnEvent: 0.3,
   contextAlphaOnEventIsEnabled: true,
+  backgroundColor: null,
 };
 
 export const DEFAULT_RENDERER_WIDTH = 640;


### PR DESCRIPTION
The following PR adds additional property (`render.backgroundColor`) that can be set via view settings. It supports hex colors and `Color` objects, including transparent colors (RGBA, HSLA, ...).

To change the background color, call the following code:

```typescript
orb.view.setSettings({
  render: {
    backgroundColor: '#DDDDDD',
  },
});

// reset the background color with
orb.view.setSettings({
  render: {
    backgroundColor: null,
  },
});
```

It works for both the default view and the map view. Map view is interesting when using colors with alpha (transparency channel):

![Screenshot 2023-05-03 at 18 47 19](https://user-images.githubusercontent.com/2602830/235985335-7e6373d6-27c2-436d-9271-bedceb24863f.png)
![Screenshot 2023-05-03 at 18 46 22](https://user-images.githubusercontent.com/2602830/235985343-9cf1e0dd-3af6-4258-9040-f2ca4bd28758.png)
