### PR TITLE
New: Added support to get selected/hovered nodes and edges

### DIFF
--- a/src/models/graph.ts
+++ b/src/models/graph.ts
@@ -24,6 +24,8 @@ export interface IGraph<N extends INodeBase, E extends IEdgeBase> {
   getEdgeById(id: any): IEdge<N, E> | undefined;
   getSelectedNodes(): INode<N, E>[];
   getSelectedEdges(): IEdge<N, E>[];
+  getHoveredNodes(): INode<N, E>[];
+  getHoveredEdges(): IEdge<N, E>[];
   getNodePositions(): INodePosition[];
   setNodePositions(positions: INodePosition[]): void;
   getEdgePositions(): IEdgePosition[];
@@ -136,6 +138,24 @@ export class Graph<N extends INodeBase, E extends IEdgeBase> implements IGraph<N
    */
   getSelectedEdges(): IEdge<N, E>[] {
     return this.getEdges((edge) => edge.isSelected());
+  }
+
+  /**
+   * Returns a list of hovered nodes.
+   *
+   * @return {INode[]} List of hovered nodes
+   */
+  getHoveredNodes(): INode<N, E>[] {
+    return this.getNodes((node) => node.isHovered());
+  }
+
+  /**
+   * Returns a list of hovered edges.
+   *
+   * @return {IEdge[]} List of hovered edges
+   */
+  getHoveredEdges(): IEdge<N, E>[] {
+    return this.getEdges((edge) => edge.isHovered());
   }
 
   /**

--- a/src/models/graph.ts
+++ b/src/models/graph.ts
@@ -22,6 +22,8 @@ export interface IGraph<N extends INodeBase, E extends IEdgeBase> {
   getEdgeCount(): number;
   getNodeById(id: any): INode<N, E> | undefined;
   getEdgeById(id: any): IEdge<N, E> | undefined;
+  getSelectedNodes(): INode<N, E>[];
+  getSelectedEdges(): IEdge<N, E>[];
   getNodePositions(): INodePosition[];
   setNodePositions(positions: INodePosition[]): void;
   getEdgePositions(): IEdgePosition[];
@@ -116,6 +118,24 @@ export class Graph<N extends INodeBase, E extends IEdgeBase> implements IGraph<N
    */
   getEdgeById(id: any): IEdge<N, E> | undefined {
     return this._edges.getOne(id);
+  }
+
+  /**
+   * Returns a list of selected nodes.
+   *
+   * @return {INode[]} List of selected nodes
+   */
+  getSelectedNodes(): INode<N, E>[] {
+    return this.getNodes((node) => node.isSelected());
+  }
+
+  /**
+   * Returns a list of selected edges.
+   *
+   * @return {IEdge[]} List of selected edges
+   */
+  getSelectedEdges(): IEdge<N, E>[] {
+    return this.getEdges((edge) => edge.isSelected());
   }
 
   /**


### PR DESCRIPTION
Issue: #60 

**Description:**

This pull request addresses the issue raised regarding the lack of a straightforward way to retrieve selected/hovered nodes and edges in the library. To enhance the flexibility and functionality of the library, this PR introduces four new methods, `getSelectedNodes`, `getSelectedEdges`, `getHoveredNodes`, `getHoveredEdges`. Which enable users to retrieve all selected/hovered elements within the graph.

**Changes Made:**

- Implemented the `getSelectedNodes` method to retrieve all selected nodes.
- Implemented the `getSelectedEdges` method to retrieve all selected edges.
- Implemented the `getHoveredNodes` method to retrieve all hovered nodes.
- Implemented the `getHoveredEdges` method to retrieve all hovered edges.

**Example Usage:**

```typescript
// Retrieve selected nodes
selectedNodes = orb.data.getSelectedNodes()

// Retrieve selected edges
selectedEdges = orb.data.getSelectedEdges()

// Retrieve hovered nodes
hoveredNodes = orb.data.getHoveredNodes()

// Retrieve selected edges
hoveredEdges = orb.data.getHoveredEdges()



