### PR TITLE
New: Add support for enabling and disabling zoom (fixes #62)

### DIFF
--- a/docs/view-default.md
+++ b/docs/view-default.md
@@ -321,15 +321,17 @@ orb.events.on(OrbEventType.MOUSE_CLICK, (event) => {
 
 ### Property `interaction`
 
-The optional property `interaction` has one property that you can enable/disable:
+The optional property `interaction` has two properties that you can enable/disable:
 
 * `isDragEnabled` - property controls the dragging behavior within the application. When it is set to `true`, dragging is enabled, allowing users to interact with nodes and edges by dragging them to different positions within the graph. On the other hand, when `isDragEnabled`` is set to false, dragging functionality is disabled, preventing users from moving or repositioning nodes and edges through dragging interactions.
 
-This property provides a straightforward way to enable or disable the dragging feature based on the needs and requirements of your application. By toggling the value of `isDragEnabled`, you can easily control whether users are allowed to interactively reposition elements within the graph by dragging them. e.g:
+* `isZoomEnabled` - This property controls the zooming behavior within the application. Setting it to `true` enables zooming, allowing users to interactively zoom in and out of the graph. Setting it to `false` disables zooming, restricting the user's ability to change the zoom level.
+
+These properties provide a straightforward way to enable or disable dragging and zooming features based on the needs and requirements of your application. By toggling the values of isDragEnabled and isZoomEnabled, you can easily control the interactivity options available to users. e.g:
 
 ```typescript
-// Disable default drag interaction
-orb.setSettings({ interaction: { isDragEnabled: false } });
+// Disable default drag interaction and enable zooming
+orb.setSettings({ interaction: { isDragEnabled: false, isZoomEnabled: true } });
 ```
 
 ### Property `simulation`

--- a/docs/view-default.md
+++ b/docs/view-default.md
@@ -83,6 +83,7 @@ interface IOrbViewSettings {
   // For graph interaction
   interaction: {
     isDragEnabled: boolean;
+    isZoomEnabled: boolean;
   };
   // Other default view parameters
   zoomFitTransitionMs: number;
@@ -155,6 +156,7 @@ const defaultSettings = {
   },
   interaction: {
     isDragEnabled: true;
+    isZoomEnabled:  true;
   },
   zoomFitTransitionMs: 200,
   isOutOfBoundsDragEnabled: false,

--- a/src/views/orb-view.ts
+++ b/src/views/orb-view.ts
@@ -25,6 +25,7 @@ import { isBoolean } from '../utils/type.utils';
 
 export interface IGraphInteractionSettings {
   isDragEnabled: boolean;
+  isZoomEnabled: boolean;
 }
 
 export interface IOrbViewSettings<N extends INodeBase, E extends IEdgeBase> {
@@ -97,6 +98,7 @@ export class OrbView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
       },
       interaction: {
         isDragEnabled: true,
+        isZoomEnabled: true,
         ...settings?.interaction
       }
     };
@@ -230,6 +232,13 @@ export class OrbView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
         this._settings.interaction.isDragEnabled =
           settings.interaction.isDragEnabled;
       }
+
+      // Check if isZoomEnabled is a boolean value
+      if (isBoolean(settings.interaction.isZoomEnabled)) {
+        // Update the internal isZoomEnabled setting based on the provided value
+        this._settings.interaction.isZoomEnabled =
+          settings.interaction.isZoomEnabled;
+      }
     }
   }
 
@@ -346,6 +355,10 @@ export class OrbView<N extends INodeBase, E extends IEdgeBase> implements IOrbVi
   };
 
   zoomed = (event: D3ZoomEvent<any, any>) => {
+    // If zoom is disabled then return
+    if(!this._settings.interaction.isZoomEnabled) {
+      return;
+    }
     this._renderer.transform = event.transform;
     setTimeout(() => {
       this._renderer.render(this._graph);


### PR DESCRIPTION
**Description:**

This pull request introduces enhancements related to zooming functionality. The changes aim to provide users with more control over zooming interactions. Here's an overview of the modifications made:

- Added a new property `isZoomEnabled` to the optional interaction object.

- `isZoomEnabled` allows users to enable or disable the zooming feature in the graph.

- When `isZoomEnabled` is set to `true`, users can interactively zoom in and out of the graph.

- When `isZoomEnabled` is set to `false`, zooming functionality is disabled, restricting users from changing the zoom level.

**Example:**

```typescript
//To enable zooming
orb.setSettings({ interaction: { isZoomEnabled: true } });
```

```typescript
//To disable zooming
orb.setSettings({ interaction: { isZoomEnabled: false } });
```