### PR TITLE
New: Added support for keyboard interaction

### DIFF
--- a/docs/view-default.md
+++ b/docs/view-default.md
@@ -84,6 +84,12 @@ interface IOrbViewSettings {
   interaction: {
     isDragEnabled: boolean;
     isZoomEnabled: boolean;
+    keyboard: {
+      isKeyboardEnabled: boolean;
+      zoomInFactor: number;
+      zoomOutFactor: number;
+      draggingFactor: number;
+    };
   };
   // Other default view parameters
   zoomFitTransitionMs: number;
@@ -157,6 +163,12 @@ const defaultSettings = {
   interaction: {
     isDragEnabled: true;
     isZoomEnabled:  true;
+    keyboard: {
+      isKeyboardEnabled: true,
+      zoomInFactor: 1.2,
+      zoomOutFactor: 0.8,
+      draggingFactor: 25
+    }
   },
   zoomFitTransitionMs: 200,
   isOutOfBoundsDragEnabled: false,
@@ -323,13 +335,19 @@ orb.events.on(OrbEventType.MOUSE_CLICK, (event) => {
 
 ### Property `interaction`
 
-The optional property `interaction` has two properties that you can enable/disable:
+The `interaction` property controls the interactivity options available to users when interacting with the graph visualization.
 
 * `isDragEnabled` - property controls the dragging behavior within the application. When it is set to `true`, dragging is enabled, allowing users to interact with nodes and edges by dragging them to different positions within the graph. On the other hand, when `isDragEnabled`` is set to false, dragging functionality is disabled, preventing users from moving or repositioning nodes and edges through dragging interactions.
 
 * `isZoomEnabled` - This property controls the zooming behavior within the application. Setting it to `true` enables zooming, allowing users to interactively zoom in and out of the graph. Setting it to `false` disables zooming, restricting the user's ability to change the zoom level.
 
-These properties provide a straightforward way to enable or disable dragging and zooming features based on the needs and requirements of your application. By toggling the values of isDragEnabled and isZoomEnabled, you can easily control the interactivity options available to users. e.g:
+* `keyboard` - This property allows you to define keyboard interaction settings:
+   * `isKeyboardEnabled` (boolean): Set this property to `true` to enable keyboard interaction within the graph visualization. When enabled, users can use keyboard shortcuts for certain interactions.
+   * `zoomInFactor` (number): The zoom-in factor determines the extent to which the graph will zoom in when the user presses the zoom-in keyboard shortcut.
+   * `zoomOutFactor` (number): The zoom-out factor determines the extent to which the graph will zoom out when the user presses the zoom-out keyboard shortcut.
+   * `draggingFactor` (number): The dragging factor specifies the speed at which nodes and edges will move when the user interacts with them using keyboard shortcuts for dragging.
+
+By customizing the interaction property, you can enable or disable dragging and zooming features based on the needs and requirements of your graph visualization application. Additionally, you can also choose to enable keyboard interactions for further user control and convenience. e.g:
 
 ```typescript
 // Disable default drag interaction and enable zooming

--- a/src/renderer/canvas/canvas-renderer.ts
+++ b/src/renderer/canvas/canvas-renderer.ts
@@ -245,6 +245,47 @@ export class CanvasRenderer<N extends INodeBase, E extends IEdgeBase> extends Em
     return zoomIdentity.translate(newX, newY).scale(newZoom);
   }
 
+  getZoomTransform(zoomFactor: number): ZoomTransform {
+    const previousZoom = this.transform.k;
+    const newZoom = Math.max(
+      Math.min(zoomFactor * previousZoom, this._settings.maxZoom),
+      this._settings.minZoom
+    );
+    return zoomIdentity.scale(newZoom);
+  }
+
+  getDragLeftTransform(draggingFactor: number): ZoomTransform {
+    const currentTransform = this.transform;
+    const newX = currentTransform.x + draggingFactor;
+    return zoomIdentity
+      .translate(newX, currentTransform.y)
+      .scale(currentTransform.k);
+  }
+
+  getDragRightTransform(draggingFactor: number): ZoomTransform {
+    const currentTransform = this.transform;
+    const newX = currentTransform.x - draggingFactor;
+    return zoomIdentity
+      .translate(newX, currentTransform.y)
+      .scale(currentTransform.k);
+  }
+
+  getDragUpTransform(draggingFactor: number): ZoomTransform {
+    const currentTransform = this.transform;
+    const newY = currentTransform.y + draggingFactor;
+    return zoomIdentity
+      .translate(currentTransform.x, newY)
+      .scale(currentTransform.k);
+  }
+
+  getDragDownTransform(draggingFactor: number): ZoomTransform {
+    const currentTransform = this.transform;
+    const newY = currentTransform.y - draggingFactor;
+    return zoomIdentity
+      .translate(currentTransform.x, newY)
+      .scale(currentTransform.k);
+  }
+
   getSimulationPosition(canvasPoint: IPosition): IPosition {
     // By default, the canvas is translated by (width/2, height/2) to center the graph.
     // The simulation is not, it's starting coordinates are at (0, 0).

--- a/src/renderer/shared.ts
+++ b/src/renderer/shared.ts
@@ -59,6 +59,16 @@ export interface IRenderer<N extends INodeBase, E extends IEdgeBase> extends IEm
 
   getFitZoomTransform(graph: IGraph<N, E>): ZoomTransform;
 
+  getZoomTransform(zoomFactor: number): ZoomTransform;
+
+  getDragLeftTransform(draggingFactor: number): ZoomTransform;
+
+  getDragRightTransform(draggingFactor: number): ZoomTransform;
+
+  getDragUpTransform(draggingFactor: number): ZoomTransform;
+
+  getDragDownTransform(draggingFactor: number): ZoomTransform;
+
   getSimulationPosition(canvasPoint: IPosition): IPosition;
 
   /**

--- a/src/renderer/webgl/webgl-renderer.ts
+++ b/src/renderer/webgl/webgl-renderer.ts
@@ -66,6 +66,30 @@ export class WebGLRenderer<N extends INodeBase, E extends IEdgeBase> extends Emi
     throw new Error('Method not implemented.');
   }
 
+  getZoomTransform(zoomFactor: number): ZoomTransform {
+    console.log("zoomFactor:", zoomFactor);
+    throw new Error("Method not implemented.");
+  }
+  getDragLeftTransform(draggingFactor: number): ZoomTransform {
+    console.log("draggingFactor:", draggingFactor);
+    throw new Error("Method not implemented.");
+  }
+
+  getDragRightTransform(draggingFactor: number): ZoomTransform {
+    console.log("draggingFactor:", draggingFactor);
+    throw new Error("Method not implemented.");
+  }
+
+  getDragUpTransform(draggingFactor: number): ZoomTransform {
+    console.log("draggingFactor:", draggingFactor);
+    throw new Error("Method not implemented.");
+  }
+
+  getDragDownTransform(draggingFactor: number): ZoomTransform {
+    console.log("draggingFactor:", draggingFactor);
+    throw new Error("Method not implemented.");
+  }
+
   getSimulationPosition(canvasPoint: IPosition): IPosition {
     console.log('canvasPoint:', canvasPoint);
     throw new Error('Method not implemented.');


### PR DESCRIPTION
This PR introduces and new feature that allows user to Drag/Zoom graph in Canvas using `keyboard`. Allowing users to control the scale of zoom using `zoomInFactor` and `zoomOutFactor` also `draggingFactor` allows to control dragging speed. This feature enhances the usability of the library by giving users more control over interactivity.