### PR TITLE
New Added support for custom edge line style

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -142,6 +142,7 @@ style properties:
 | `widthHover`          | number              | Edge line width on mouse hover event. If not defined `width` is used. |
 | `widthSelected`       | number              | Edge line width on mouse click event. If not defined `width` is used. |
 | `zIndex`              | number              | Specifies the stack order of an element during rendering. The default is `0`. |
+| `edgeLineStyle`       | object              | Allows to customize the style of edges in the graph visualization. The default is `{type: 'solid', dashPattern: []}` |
 
 ## Default style values
 

--- a/src/models/edge.ts
+++ b/src/models/edge.ts
@@ -1,6 +1,7 @@
 import { INodeBase, INode } from './node';
 import { GraphObjectState } from './state';
 import { Color, IPosition, ICircle, getDistanceToLine } from '../common';
+import { isArrayOfNumbers } from '../utils/type.utils';
 
 const CURVED_CONTROL_POINT_OFFSET_MIN_SIZE = 4;
 const CURVED_CONTROL_POINT_OFFSET_MULTIPLIER = 4;
@@ -25,6 +26,18 @@ export interface IEdgePosition {
   target: any;
 }
 
+export enum EdgeLineStyleType {
+  SOLID = "solid",
+  DASHED = "dashed",
+  DOTTED = "dotted",
+  CUSTOM = "custom",
+}
+
+export interface IEdgeLineStyle {
+  type: EdgeLineStyleType;
+  dashPattern: number[];
+}
+
 /**
  * Edge style properties used to style the edge (color, width, label, etc.).
  */
@@ -46,6 +59,7 @@ export type IEdgeStyle = Partial<{
   widthHover: number;
   widthSelected: number;
   zIndex: number;
+  edgeLineStyle: IEdgeLineStyle;
 }>;
 
 export interface IEdgeData<N extends INodeBase, E extends IEdgeBase> {
@@ -89,6 +103,7 @@ export interface IEdge<N extends INodeBase, E extends IEdgeBase> {
   hasShadow(): boolean;
   getWidth(): number;
   getColor(): Color | string | undefined;
+  getEdgeLineStyle(): IEdgeLineStyle;
 }
 
 export class EdgeFactory {
@@ -255,6 +270,20 @@ abstract class Edge<N extends INodeBase, E extends IEdgeBase> implements IEdge<N
     }
 
     return color;
+  }
+
+  getEdgeLineStyle(): IEdgeLineStyle {
+    const edgeLineStyle: IEdgeLineStyle = {
+      type: EdgeLineStyleType.SOLID,
+      dashPattern: [],
+    };
+    if (this.style.edgeLineStyle !== undefined) {
+      edgeLineStyle.type = this.style.edgeLineStyle.type;
+      if (isArrayOfNumbers(this.style.edgeLineStyle.dashPattern)) {
+        edgeLineStyle.dashPattern = this.style.edgeLineStyle.dashPattern;
+      }
+    }
+    return edgeLineStyle;
   }
 }
 

--- a/src/renderer/canvas/edge/shared.ts
+++ b/src/renderer/canvas/edge/shared.ts
@@ -10,3 +10,7 @@ export interface IEdgeArrow {
   angle: number;
   length: number;
 }
+
+export const DEFAULT_SOLID_LINE_PATTERN: number[] = [];
+export const DEFAULT_DASHED_LINE_PATTERN: number[] = [5, 5];
+export const DEFAULT_DOTTED_LINE_PATTERN: number[] = [1, 1];

--- a/src/renderer/canvas/edge/types/edge-curved.ts
+++ b/src/renderer/canvas/edge/types/edge-curved.ts
@@ -1,6 +1,16 @@
 import { INode, INodeBase } from '../../../../models/node';
-import { EdgeCurved, IEdgeBase } from '../../../../models/edge';
-import { IBorderPosition, IEdgeArrow } from '../shared';
+import {
+  EdgeCurved,
+  EdgeLineStyleType,
+  IEdgeBase,
+} from "../../../../models/edge";
+import {
+  DEFAULT_DASHED_LINE_PATTERN,
+  DEFAULT_DOTTED_LINE_PATTERN,
+  DEFAULT_SOLID_LINE_PATTERN,
+  IBorderPosition,
+  IEdgeArrow,
+} from "../shared";
 import { IPosition } from '../../../../common';
 
 export const drawCurvedLine = <N extends INodeBase, E extends IEdgeBase>(
@@ -18,6 +28,28 @@ export const drawCurvedLine = <N extends INodeBase, E extends IEdgeBase>(
   context.beginPath();
   context.moveTo(sourcePoint.x, sourcePoint.y);
   context.quadraticCurveTo(controlPoint.x, controlPoint.y, targetPoint.x, targetPoint.y);
+
+  const edgeLineStyleType = edge.getEdgeLineStyle().type;
+  switch (edgeLineStyleType) {
+    case EdgeLineStyleType.DASHED:
+      context.setLineDash(DEFAULT_DASHED_LINE_PATTERN);
+      break;
+    case EdgeLineStyleType.DOTTED:
+      context.setLineDash(DEFAULT_DOTTED_LINE_PATTERN);
+      break;
+    case EdgeLineStyleType.SOLID:
+      context.setLineDash(DEFAULT_SOLID_LINE_PATTERN);
+      break;
+    case EdgeLineStyleType.CUSTOM: {
+      const dashPattern: number[] = edge.getEdgeLineStyle().dashPattern;
+      context.setLineDash(dashPattern);
+      break;
+    }
+    default:
+      context.setLineDash(DEFAULT_SOLID_LINE_PATTERN);
+      break;
+  }
+
   context.stroke();
 };
 

--- a/src/renderer/canvas/edge/types/edge-loopback.ts
+++ b/src/renderer/canvas/edge/types/edge-loopback.ts
@@ -1,6 +1,16 @@
 import { INode, INodeBase } from '../../../../models/node';
-import { EdgeLoopback, IEdgeBase } from '../../../../models/edge';
-import { IBorderPosition, IEdgeArrow } from '../shared';
+import {
+  EdgeLineStyleType,
+  EdgeLoopback,
+  IEdgeBase,
+} from "../../../../models/edge";
+import {
+  DEFAULT_DASHED_LINE_PATTERN,
+  DEFAULT_DOTTED_LINE_PATTERN,
+  DEFAULT_SOLID_LINE_PATTERN,
+  IBorderPosition,
+  IEdgeArrow,
+} from "../shared";
 import { ICircle, IPosition } from '../../../../common';
 
 export const drawLoopbackLine = <N extends INodeBase, E extends IEdgeBase>(
@@ -13,6 +23,28 @@ export const drawLoopbackLine = <N extends INodeBase, E extends IEdgeBase>(
   context.beginPath();
   context.arc(x, y, radius, 0, 2 * Math.PI, false);
   context.closePath();
+
+  const edgeLineStyleType = edge.getEdgeLineStyle().type;
+  switch (edgeLineStyleType) {
+    case EdgeLineStyleType.DASHED:
+      context.setLineDash(DEFAULT_DASHED_LINE_PATTERN);
+      break;
+    case EdgeLineStyleType.DOTTED:
+      context.setLineDash(DEFAULT_DOTTED_LINE_PATTERN);
+      break;
+    case EdgeLineStyleType.SOLID:
+      context.setLineDash(DEFAULT_SOLID_LINE_PATTERN);
+      break;
+    case EdgeLineStyleType.CUSTOM: {
+      const dashPattern: number[] = edge.getEdgeLineStyle().dashPattern;
+      context.setLineDash(dashPattern);
+      break;
+    }
+    default:
+      context.setLineDash(DEFAULT_SOLID_LINE_PATTERN);
+      break;
+  }
+
   context.stroke();
 };
 

--- a/src/renderer/canvas/edge/types/edge-straight.ts
+++ b/src/renderer/canvas/edge/types/edge-straight.ts
@@ -1,6 +1,16 @@
 import { INodeBase, INode } from '../../../../models/node';
-import { EdgeStraight, IEdgeBase } from '../../../../models/edge';
-import { IBorderPosition, IEdgeArrow } from '../shared';
+import {
+  EdgeLineStyleType,
+  EdgeStraight,
+  IEdgeBase,
+} from "../../../../models/edge";
+import {
+  DEFAULT_DASHED_LINE_PATTERN,
+  DEFAULT_DOTTED_LINE_PATTERN,
+  DEFAULT_SOLID_LINE_PATTERN,
+  IBorderPosition,
+  IEdgeArrow,
+} from "../shared";
 
 export const drawStraightLine = <N extends INodeBase, E extends IEdgeBase>(
   context: CanvasRenderingContext2D,
@@ -17,6 +27,28 @@ export const drawStraightLine = <N extends INodeBase, E extends IEdgeBase>(
   context.beginPath();
   context.moveTo(sourcePoint.x, sourcePoint.y);
   context.lineTo(targetPoint.x, targetPoint.y);
+
+  const edgeLineStyleType = edge.getEdgeLineStyle().type;
+  switch (edgeLineStyleType) {
+    case EdgeLineStyleType.DASHED:
+      context.setLineDash(DEFAULT_DASHED_LINE_PATTERN);
+      break;
+    case EdgeLineStyleType.DOTTED:
+      context.setLineDash(DEFAULT_DOTTED_LINE_PATTERN);
+      break;
+    case EdgeLineStyleType.SOLID:
+      context.setLineDash(DEFAULT_SOLID_LINE_PATTERN);
+      break;
+    case EdgeLineStyleType.CUSTOM: {
+      const dashPattern: number[] = edge.getEdgeLineStyle().dashPattern;
+      context.setLineDash(dashPattern);
+      break;
+    }
+    default:
+      context.setLineDash(DEFAULT_SOLID_LINE_PATTERN);
+      break;
+  }
+
   context.stroke();
 };
 

--- a/src/utils/type.utils.ts
+++ b/src/utils/type.utils.ts
@@ -87,3 +87,18 @@ export const isNull = (value: any): value is null => {
 export const isFunction = (value: any): value is Function => {
   return typeof value === 'function';
 };
+
+/**
+ * Type check for array of numbers
+ *
+ * @param {any} value Any value
+ * @return {boolean} True if it is a array of numbers, false otherwise
+ */
+export const isArrayOfNumbers = (value: any): value is boolean => {
+  if (!isArray(value)) {
+    return false;
+  }
+
+  const isNotNumber = value.some((element) => !isNumber(element));
+  return !isNotNumber;
+};


### PR DESCRIPTION
This PR introduces a new feature allowing users to have greater control over the appearance of edges in the graph by implementing custom edge line styles. User can set a `Solid`, `Dashed`, `Dotted` or even `custom` edges by defining own edge patterns.