### PR TITLE
New: Add state setters with options

### DIFF
--- a/src/models/edge.ts
+++ b/src/models/edge.ts
@@ -1,7 +1,7 @@
 import { INodeBase, INode } from './node';
-import { GraphObjectState, IGraphObjectStateParameters } from './state';
+import { GraphObjectState, IGraphObjectStateOptions, IGraphObjectStateParameters } from './state';
 import { Color, IPosition, ICircle, getDistanceToLine } from '../common';
-import { isArrayOfNumbers, isFunction } from '../utils/type.utils';
+import { isArrayOfNumbers, isFunction, isNumber, isPlainObject } from '../utils/type.utils';
 import { IObserver, ISubject, Subject } from '../utils/observer.utils';
 import { patchProperties } from '../utils/object.utils';
 
@@ -420,36 +420,30 @@ abstract class Edge<N extends INodeBase, E extends IEdgeBase> extends Subject im
       result = arg;
     }
 
-    if (typeof result === 'number') {
+    if (isNumber(result)) {
       this._state = result;
-    } else if (typeof result === 'object') {
+    } else if (isPlainObject(result) && result.options) {
       const options = result.options;
 
-      if (options && options.isToggle) {
-        this._toggleState(result.state);
-      } else {
-        this._state = result.state;
-      }
+      this._state = this._handleState(result.state, options);
 
-      if (options) {
-        this.notifyListeners({
-          id: this.id,
-          type: 'edge',
-          options: options,
-        });
+      this.notifyListeners({
+        id: this.id,
+        type: 'edge',
+        options: options,
+      });
 
-        return;
-      }
+      return;
     }
 
     this.notifyListeners();
   }
 
-  private _toggleState(state: number) {
-    if (this._state === state) {
-      this._state = GraphObjectState.NONE;
+  private _handleState(state: number, options: IGraphObjectStateOptions): number {
+    if (options.isToggle && this._state === state) {
+      return GraphObjectState.NONE;
     } else {
-      this._state = state;
+      return state;
     }
   }
 }

--- a/src/models/edge.ts
+++ b/src/models/edge.ts
@@ -422,25 +422,27 @@ abstract class Edge<N extends INodeBase, E extends IEdgeBase> extends Subject im
 
     if (isNumber(result)) {
       this._state = result;
-    } else if (isPlainObject(result) && result.options) {
+    } else if (isPlainObject(result)) {
       const options = result.options;
 
       this._state = this._handleState(result.state, options);
 
-      this.notifyListeners({
-        id: this.id,
-        type: 'edge',
-        options: options,
-      });
+      if (options) {
+        this.notifyListeners({
+          id: this.id,
+          type: 'edge',
+          options: options,
+        });
 
-      return;
+        return;
+      }
     }
 
     this.notifyListeners();
   }
 
-  private _handleState(state: number, options: IGraphObjectStateOptions): number {
-    if (options.isToggle && this._state === state) {
+  private _handleState(state: number, options?: Partial<IGraphObjectStateOptions>): number {
+    if (options?.isToggle && this._state === state) {
       return GraphObjectState.NONE;
     } else {
       return state;

--- a/src/models/graph.ts
+++ b/src/models/graph.ts
@@ -378,6 +378,27 @@ export class Graph<N extends INodeBase, E extends IEdgeBase> extends Subject imp
   }
 
   update(data?: IObserverDataPayload): void {
+    if (data && 'type' in data && 'options' in data && 'isSingle' in data.options) {
+      if (data.type === 'node' && data.options.isSingle) {
+        const nodes = this._nodes.getAll();
+
+        for (let i = 0; i < nodes.length; i++) {
+          if (nodes[i].id !== data.id) {
+            nodes[i].clearState();
+          }
+        }
+      }
+
+      if (data.type === 'edge' && data.options.isSingle) {
+        const edges = this._edges.getAll();
+
+        for (let i = 0; i < edges.length; i++) {
+          if (edges[i].id !== data.id) {
+            edges[i].clearState();
+          }
+        }
+      }
+    }
     this.notifyListeners(data);
   }
 

--- a/src/models/node.ts
+++ b/src/models/node.ts
@@ -463,8 +463,7 @@ export class Node<N extends INodeBase, E extends IEdgeBase> extends Subject impl
   setPosition(
     callback: (node: INode<N, E>) => INodeCoordinates | INodeMapCoordinates | INodePosition,
     isInner?: boolean,
-  ): // options: ISetPositionOptions = defaultOptions {isInner: true} + patch Partial options
-  void;
+  ): void;
   setPosition(
     arg:
       | INodeCoordinates

--- a/src/models/node.ts
+++ b/src/models/node.ts
@@ -548,18 +548,20 @@ export class Node<N extends INodeBase, E extends IEdgeBase> extends Subject impl
 
     if (isNumber(result)) {
       this._state = result;
-    } else if (isPlainObject(result) && result.options) {
+    } else if (isPlainObject(result)) {
       const options = result.options;
 
       this._state = this._handleState(result.state, options);
 
-      this.notifyListeners({
-        id: this.id,
-        type: 'node',
-        options: options,
-      });
+      if (options) {
+        this.notifyListeners({
+          id: this.id,
+          type: 'node',
+          options: options,
+        });
 
-      return;
+        return;
+      }
     }
 
     this.notifyListeners();
@@ -569,8 +571,8 @@ export class Node<N extends INodeBase, E extends IEdgeBase> extends Subject impl
     return isPointInRectangle(this.getBoundingBox(), point);
   }
 
-  private _handleState(state: number, options: IGraphObjectStateOptions): number {
-    if (options.isToggle && this._state === state) {
+  private _handleState(state: number, options?: Partial<IGraphObjectStateOptions>): number {
+    if (options?.isToggle && this._state === state) {
       return GraphObjectState.NONE;
     } else {
       return state;

--- a/src/models/state.ts
+++ b/src/models/state.ts
@@ -8,17 +8,17 @@ export const GraphObjectState = {
 };
 
 export interface IGraphObjectStateOptions {
-  isToggle?: boolean;
-  isSingle?: boolean;
+  isToggle: boolean;
+  isSingle: boolean;
 }
 
 export interface IGraphObjectStateParameters {
   state: number;
-  options: IGraphObjectStateOptions;
+  options?: Partial<IGraphObjectStateOptions>;
 }
 
 export interface ISetStateDataPayload {
   id: any;
   type: GraphObject;
-  options: IGraphObjectStateOptions;
+  options: Partial<IGraphObjectStateOptions>;
 }

--- a/src/models/state.ts
+++ b/src/models/state.ts
@@ -1,6 +1,24 @@
+import { GraphObject } from '../utils/observer.utils';
+
 // Enum is dismissed so user can define custom additional events (numbers)
 export const GraphObjectState = {
   NONE: 0,
   SELECTED: 1,
   HOVERED: 2,
 };
+
+export interface IGraphObjectStateOptions {
+  isToggle?: boolean;
+  isSingle?: boolean;
+}
+
+export interface IGraphObjectStateParameters {
+  state: number;
+  options: IGraphObjectStateOptions;
+}
+
+export interface ISetStateDataPayload {
+  id: any;
+  type: GraphObject;
+  options: IGraphObjectStateOptions;
+}

--- a/src/utils/observer.utils.ts
+++ b/src/utils/observer.utils.ts
@@ -1,6 +1,9 @@
 import { INodeCoordinates, INodeMapCoordinates, INodePosition } from '../models/node';
+import { ISetStateDataPayload } from '../models/state';
 
-export type IObserverDataPayload = INodePosition | INodeCoordinates | INodeMapCoordinates;
+export type GraphObject = 'node' | 'edge';
+
+export type IObserverDataPayload = INodePosition | INodeCoordinates | INodeMapCoordinates | ISetStateDataPayload;
 
 export interface IObserver {
   update(data?: IObserverDataPayload): void;


### PR DESCRIPTION
Resolves #68

As an enhancement to the freshly implemented getters and setters, this PR introduces a new way to set the state of nodes and edges using objects that specify state with additional parameters such as `isSingle` and `isToggle`. Now, it is possible to use both the regular setter:
```typescript
node.setState(state)
```
and the new setter:
```typescript
node.setState({ state: GraphObjectState.SELECTED, options: { isSingle: true } })
```
```typescript
edge.setState({ state: GraphObjectState.SELECTED, options: { isSingle: false, isToggle: true } })
```
and so on. This provides more customization flexibility to the user, with default values for these parameters set to `false`. It should be easily extendable for adding even more options.