### PR TITLE
Fix: Disable source map generation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "esnext",
     "lib": ["DOM", "ES6"],
     "declaration": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "outDir": "./dist",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
This PR disables unnecessary source map generation while building.

Fixes #99 